### PR TITLE
docs: rewrite READMEs and add keypair generation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ pkg
 Cargo.lock
 *.log
 tx.json
-tss-signer-keypair.json
+tss_signer_keypair.json
+
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,237 @@
-# TSS WASM
-A portable lightweight client application for threshold ECDSA (based on [GG18](https://eprint.iacr.org/2019/114.pdf)), built on&for [multi-party-ecdsa](https://github.com/ZenGo-X/multi-party-ecdsa) :
-1) Wasm/Web
-2) HW friendly, like [TEE](https://github.com/0xEigenLabs/eigencc)
+# TSS Signer
 
-# Npm publish
+A Threshold Signature Scheme (TSS) implementation for the Liberdus cross-chain bridge. Uses the [GG18](https://eprint.iacr.org/2019/114.pdf) multi-party ECDSA protocol to enable distributed, trustless signing with a **3-of-5 threshold** configuration — no single party can sign unilaterally.
 
-* node: npm run build_node
-* web: npm run build
+Supports bridging between the Liberdus network and EVM chains (Polygon Amoy, BSC Testnet).
 
-## Latest release
+## Architecture
 
-web: @ieigen/tss-wasm@0.0.8
-
-nodejs: @ieigen/tss-wasm-node@0.0.7, node 18.0+ is required
-
-# Test
-
-## Unit Test
 ```
+┌─────────────────────────────────────────────────────┐
+│              Coordinator  (coordinator/)            │
+│  • Monitors EVM chains for BridgedOut/BridgedIn     │
+│  • Polls Liberdus for coin-to-token transfers       │
+│  • Persists bridge transactions to SQLite           │
+│  • Relays keygen/signing round data between parties │
+└──────────────────────▲──────────────────────────────┘
+                       │  HTTP (localhost:8000)
+┌──────────────────────┴──────────────────────────────┐
+│                  TSS Party Nodes (×5)               │
+│  scripts/tss-party.ts — compiled to dist/           │
+│  • Poll coordinator every 10s for pending txs       │
+│  • Verify each tx on-chain before queuing           │
+│  • Coordinate 10-round GG18 signing                 │
+│  • Submit signed txs to destination chain           │
+└─────────────────────────────────────────────────────┘
+```
+
+### Language split
+
+| Layer | Language | Purpose |
+|---|---|---|
+| `src/` | Rust → WASM | GG18 crypto: keygen (5 rounds), signing (10 rounds) |
+| `scripts/tss-party.ts` | TypeScript | Orchestration: event monitoring, queue, signing flow |
+| `coordinator/` | TypeScript (Node.js) | Round relay, transaction DB, on-chain monitoring |
+| `pkg/` | Generated WASM | Output of `wasm-pack build` |
+
+## Prerequisites
+
+- Rust + `wasm-pack` ([install](https://rustwasm.github.io/wasm-pack/installer/))
+- Node.js 18+
+- PM2 (`npm install -g pm2`)
+
+## Setup
+
+### 1. Build the WASM module
+
+```bash
+npm run build_node
+```
+
+### 2. Compile the TSS party script
+
+```bash
+npm run compile-tss
+```
+
+### 3. Configure chains and params
+
+- **`params.json`** — TSS parameters. Default: `{"parties": 5, "threshold": 3}`
+- **`chain-config.json`** — RPC endpoints, contract addresses, gas config per chain.
+
+### 4. Run keygen (first time only)
+
+All 5 parties must complete keygen before any signing can occur. Keygen produces per-party keystore files in `keystores/`. Refer to the keygen script for details.
+
+### 5. Start the coordinator
+
+```bash
+cd coordinator
+npm install
+npm run dev        # development (ts-node + nodemon)
+# or
+npm run build && npm start   # production
+```
+
+See [coordinator/README.md](coordinator/README.md) for full coordinator setup.
+
+### 6. Start all TSS parties
+
+```bash
+npm run start-tss   # starts 5 PM2 processes
+```
+
+## Build Commands
+
+```bash
+# Build WASM for Node.js
+npm run build_node
+
+# Build WASM for web (webpack)
 npm run build
+
+# Compile TypeScript party script
+npm run compile-tss
+
+# Compile + run a single party (for testing)
+npm run tss-party
+```
+
+## PM2 Process Management
+
+```bash
+npm run start-tss    # start all 5 party processes
+npm run stop-tss     # stop all
+npm run restart-tss  # restart all
+npm run logs-tss     # stream PM2 logs
+npm run status-tss   # show process status
+```
+
+Each party process runs with `--expose-gc` and a 2 GB memory limit. GC is forced when heap exceeds 256 MB.
+
+## Bridge Transaction Flow
+
+**Token-to-Coin (EVM → Liberdus):**
+1. Coordinator detects `BridgedOut` event on EVM contract and saves it as PENDING in SQLite
+2. TSS parties poll coordinator every 10s for unprocessed transactions (`GET /transaction?unprocessed=true`)
+3. Each party independently verifies the transaction on-chain before queuing it
+4. Parties coordinate 10-round GG18 signing through the coordinator's round relay
+5. Winning party broadcasts the signed tx to Liberdus and reports COMPLETED to coordinator
+
+**Coin-to-Token (Liberdus → EVM):**
+1. Coordinator polls the Liberdus collector API for bridge transfers and saves them as PENDING
+2. TSS parties pick up the pending transaction, verify on-chain, sign, and submit to the target EVM chain
+
+## Key Files
+
+| Path | Description |
+|---|---|
+| `scripts/tss-party.ts` | Main party orchestration (~3000 lines) |
+| `src/api.rs` | WASM-exported keygen/signing round functions |
+| `coordinator/src/server.ts` | Coordinator entry point |
+| `chain-config.json` | Multi-chain RPC and contract configuration |
+| `params.json` | TSS parameters (parties, threshold) |
+| `keystores/` | Per-party key shares (keygen) + auth keypairs (`tss_signer_keypair_party_N.json`) |
+| `scripts/generate-keypairs.js` | Generates auth keypairs for TSS parties |
+| `ecosystem.config.js` | PM2 process configuration |
+
+## TSS → Coordinator Authentication
+
+TSS parties sign every HTTP request they send to the coordinator using **Shardus Crypto** (Ed25519 + Blake2b-keyed hash). This prevents unauthorized clients from injecting round data or manipulating party signup.
+
+The auth layer is implemented in [`src/shardus_crypto.rs`](src/shardus_crypto.rs) (compiled into the WASM module) and verified by the coordinator in [`coordinator/src/auth.ts`](coordinator/src/auth.ts).
+
+### Enabling / disabling
+
+Auth is controlled by the `enableShardusCryptoAuth` field in `chain-config.json`:
+
+```json
+{ "enableShardusCryptoAuth": true }
+```
+
+It can also be forced on/off via environment variable:
+
+```bash
+ENABLE_SHARDUS_CRYPTO_AUTH=true   # override chain-config.json
+ENABLE_SHARDUS_CRYPTO_AUTH=false  # disable regardless of config
+```
+
+**For local development**, leave `enableShardusCryptoAuth` unset or `false` — parties will skip signing and the coordinator will accept all requests without verification.
+
+### Generating keypairs
+
+Each TSS party needs its own Ed25519 keypair. Use the provided script to generate them:
+
+```bash
+# Generate keypairs for all 5 parties (skips existing files)
+node scripts/generate-keypairs.js
+
+# Generate for a specific number of parties
+node scripts/generate-keypairs.js --parties 5
+
+# Regenerate a single party's keypair
+node scripts/generate-keypairs.js --party 3 --force
+```
+
+Keypairs are written to `keystores/tss_signer_keypair_party_N.json`:
+
+```json
+{
+  "publicKey": "<64-char hex>",
+  "secretKey": "<128-char hex>"
+}
+```
+
+The script also prints a ready-to-paste `coordinator/allowed-tss-signers.json` block containing all generated public keys. The coordinator uses this whitelist to accept only requests signed by known party nodes.
+
+Keys can also be supplied via environment variables instead of files:
+
+```bash
+TSS_SIGNER_PUB_KEY=<64-char-hex>
+TSS_SIGNER_SEC_KEY=<128-char-hex>
+TSS_SIGNER_KEYPAIR_FILE=/path/to/custom-keypair.json   # override file path
+```
+
+### How signing works
+
+When auth is enabled, the WASM module wraps every coordinator request body as:
+
+```json
+{
+  "payload": <original body>,
+  "ts": <unix ms>,
+  "sign": {
+    "owner": "<public key hex>",
+    "sig":   "<ed25519 signature + digest hex>"
+  }
+}
+```
+
+The coordinator verifies the signature and rejects requests from keys not in the whitelist.
+
+## TSS Protocol Details
+
+**Keygen (5 rounds):** All 5 parties participate. Output: shared public key + individual key shares written to `keystores/`.
+
+**Signing (10 rounds):** Any 3 of 5 parties suffice. Each round posts/fetches data through the coordinator's in-memory relay (`/set`, `/get`). Output: ECDSA signature broadcast to the target chain.
+
+## Running Tests
+
+```bash
+# Rust unit tests
+cargo test
+
+# WASM tests (requires build_node first)
 npm run test
 ```
 
-## Function Test via NodeJS
-```
-cargo build --examples --release
-./target/release/examples/gg18_sm_manager
+## Upstream / Attribution
 
-# open another console
-npm run build_node
-node scripts/run_keygen_sign_node.js
-```
+This project is built on top of [@ieigen/tss-wasm](https://github.com/0xEigenLabs/tss-wasm) by EigenLabs, which provides the GG18 WASM implementation. The original npm packages are:
 
-## Function Test via Web
+- `@ieigen/tss-wasm@0.0.8` (web)
+- `@ieigen/tss-wasm-node@0.0.7` (Node.js, requires Node 18+)
 
-```
-cargo build --examples --release
-./target/release/examples/gg18_sm_manager
+## License
 
-# open another console
-npm run build
-export NODE_OPTIONS=--openssl-legacy-provider
-npm run webpack && npm run webpack-dev-server
-```
-
-Open `http://localhost:8080/` in browser, check out the output in `console`.
-
-# Compile SM server by Docker
-
-```
-docker build -t ieigen:tss-sm-server --build-arg "BUILDARCH=$(uname -m)" -f sm.dockerfile .
-docker run -d -p 8000:8000 -v $PWD/params.json:/tss-wasm/params.json ieigen:tss-sm-server
-```
-
-# licence
-GPL & Apache-2.0
+Apache-2.0

--- a/coordinator/README.md
+++ b/coordinator/README.md
@@ -1,153 +1,238 @@
-# TSS Coordinator Node
+# TSS Coordinator
 
-A secure, highly available coordinator implementation for Threshold Signature Scheme (TSS) in Node.js, designed to replace the single-point-of-failure server manager in the original Rust implementation.
+An Express.js server that acts as the coordination hub for the Liberdus TSS bridge signer. It handles two distinct responsibilities:
 
-## Features
+1. **Round relay** — Relays keygen/signing round data between TSS party nodes via an in-memory key-value store.
+2. **Transaction lifecycle** — Monitors EVM chains and Liberdus for bridge events, persists transactions to SQLite, and serves pending transactions to TSS parties for signing.
 
-- **Distributed Architecture**: Multiple coordinator nodes work together for high availability
-- **Secure Communication**: JWT-based authentication and authorization
-- **State Synchronization**: Redis-based distributed state management
-- **Load Balancing**: NGINX load balancer for distributing requests
-- **Rate Limiting**: Protection against DoS attacks
-- **Detailed Logging**: Structured logging for monitoring and debugging
-- **Docker Ready**: Easy deployment with Docker and Docker Compose
+The coordinator must be running before any TSS party node can perform keygen or signing.
 
 ## Prerequisites
 
-- Node.js 18+ (for development)
-- Docker and Docker Compose (for containerized deployment)
-- Redis (automatically set up with Docker Compose)
+- Node.js 18+
 
-## Getting Started
-
-### Local Development
-
-1. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-2. Create a `.env` file based on `.env.example`:
-   ```bash
-   cp .env.example .env
-   ```
-
-3. Start Redis locally or use Docker:
-   ```bash
-   docker run -d -p 6379:6379 redis:alpine
-   ```
-
-4. Run the development server:
-   ```bash
-   npm run dev
-   ```
-
-### Docker Deployment
-
-Use Docker Compose to start the entire system:
+## Setup
 
 ```bash
-docker-compose up -d
+npm install
 ```
 
-This will start:
-- 3 coordinator nodes (ports 8000, 8001, 8002)
-- Redis instance (port 6379)
-- NGINX load balancer (port 80)
+### Configuration files
 
-## API Endpoints
+The coordinator reads two config files from the repository root (one level up from `coordinator/`):
 
-### Public Endpoints
+- **`../params.json`** — TSS parameters (`parties`, `threshold`). Used by signup endpoints.
+- **`../chain-config.json`** — RPC endpoints, contract addresses, deployment blocks, and feature flags. Used for on-chain monitoring.
 
-- `GET /health`: Check service health
+### Authentication (optional)
 
-### Authentication Required Endpoints
+The coordinator supports optional request authentication using Shardus Crypto signatures. When enabled, all round-relay endpoints (`/get`, `/set`, `/signupkeygen`, `/signupsign`) require requests to be signed by a whitelisted TSS party key.
 
-All endpoints except `/health` require authentication:
+**To enable auth:**
 
-- For signup endpoints (`/signupkeygen`, `/signupsign`): API Key via `X-API-Key` header
-- For communication endpoints (`/get`, `/set`): JWT via `Authorization: Bearer <token>` header
+Set `"enableShardusCryptoAuth": true` in `chain-config.json` (or set env var `ENABLE_SHARDUS_CRYPTO_AUTH=true`).
 
-### Endpoints
+**Whitelist file:**
 
-- `POST /signupkeygen`: Register for key generation
-  - Request: `{ "threshold": number, "parties": number }`
-  - Response: `{ "number": number, "uuid": string, "sessionId": string, "timestamp": number, "expiresAt": number }`
-
-- `POST /signupsign`: Register for signing
-  - Request: `{ "threshold": number, "parties": number }`
-  - Response: `{ "number": number, "uuid": string, "sessionId": string, "timestamp": number, "expiresAt": number }`
-
-- `POST /get`: Get a message by key
-  - Request: `{ "key": string }`
-  - Response: `{ "key": string, "value": string }`
-
-- `POST /set`: Set a message
-  - Request: `{ "key": string, "value": string }`
-  - Response: `{ "success": true }`
-
-## Integration with TSS-WASM
-
-To integrate this coordinator with the TSS-WASM library:
-
-1. Update the client-side code to use the new API endpoints
-2. Adapt the communication protocols to include JWT authentication
-3. Use the load balancer endpoint instead of the single server manager
-
-## Error Handling
-
-All API responses use structured error format:
+Create `coordinator/allowed-tss-signers.json` listing the 64-char hex public keys of all TSS party nodes:
 
 ```json
 {
-  "error": {
-    "code": "ERROR_CODE",
-    "message": "Human readable error message",
-    "requestId": "unique-request-id",
-    "timestamp": 1620000000000
+  "allowedTSSSigners": [
+    "<64-char-hex-pubkey-party-1>",
+    "<64-char-hex-pubkey-party-2>",
+    ...
+  ]
+}
+```
+
+The file path can be overridden with the `COORDINATOR_ALLOWED_TSS_SIGNER_FILE` environment variable.
+
+When auth is **disabled** (default for local development), all requests are accepted without verification.
+
+## Running
+
+```bash
+# Development — ts-node + nodemon (auto-restart on file changes)
+npm run dev
+
+# Production — compile first, then run
+npm run build
+npm start
+```
+
+The server listens on port `8000` by default. Override with the `PORT` environment variable.
+
+## Startup Sequence
+
+On startup the coordinator performs an **ordered initial sync** before accepting pending transaction queries from TSS parties:
+
+1. Scan all chains for `BridgedOut` events (EVM burn events → PENDING BRIDGE_OUT/BRIDGE_VAULT records)
+2. Scan Liberdus for coin-to-token transfers (→ PENDING BRIDGE_IN records) *(if `enableLiberdusNetwork` is set)*
+3. Scan all chains for `BridgedIn` events (marks matching records COMPLETED)
+
+Once all three scans complete, `GET /transaction?unprocessed=true` begins returning results. This prevents TSS parties from re-processing transactions that are already completed on-chain.
+
+After the initial sync, periodic polling runs on a drift-resistant scheduler:
+- EVM BridgedOut + BridgedIn: every **60 seconds**
+- Liberdus: every **10 seconds**
+
+## API Endpoints
+
+All responses follow the pattern `{ Ok: <value> }` on success or `{ Err: "<message>" }` on error.
+
+---
+
+### Round relay (in-memory, keygen/signing)
+
+#### `POST /set`
+Store a round data entry by key. Used by TSS parties to post commitments, shares, and proofs each round.
+
+**Request:** `{ "key": string, "value": string }`
+**Response:** `{ "Ok": null }`
+
+#### `POST /get`
+Retrieve a round data entry by key.
+
+**Request:** `{ "key": string }`
+**Response:** `{ "Ok": { "key": string, "value": string } }` or `404` if not found.
+
+---
+
+### Party signup (round-robin assignment)
+
+#### `POST /signupkeygen`
+Assigns a party number (1–N) for a keygen session. Resets to party 1 with a new UUID after all N parties have signed up.
+
+**Request body:** the signup key string (plain text body)
+**Response:** `{ "Ok": { "number": number, "uuid": string } }`
+
+#### `POST /signupsign`
+Same as `/signupkeygen` but for signing sessions.
+
+**Request body:** the signup key string (plain text body)
+**Response:** `{ "Ok": { "number": number, "uuid": string } }`
+
+---
+
+### Transaction management (SQLite-backed)
+
+#### `GET /transaction`
+Query bridge transactions with optional filters. Returns 10 transactions per page.
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `txId` | string | Exact lookup by transaction ID (64-char hex or `0x`-prefixed 66-char) |
+| `sender` | string | Filter by Ethereum address |
+| `type` | number | `0` = BRIDGE_IN, `1` = BRIDGE_OUT, `2` = BRIDGE_VAULT |
+| `status` | number | `0` = PENDING, `1` = PROCESSING, `2` = COMPLETED, `3` = FAILED |
+| `unprocessed` | `"true"` | Returns PENDING + PROCESSING ordered by `txTimestamp ASC` |
+| `page` | number | Page number (default: 1) |
+
+**Response:**
+```json
+{
+  "Ok": {
+    "transactions": [ ... ],
+    "totalTranactions": 42,
+    "totalPages": 5
   }
 }
 ```
 
-## Architecture
+> Returns empty results if the initial sync has not yet completed and `status=0` or `unprocessed=true` is requested.
 
-```
-┌─────────────────────────┐
-│     NGINX (Port 80)     │
-└───────────┬─────────────┘
-            │
-┌───────────┼───────────────────────────┐
-│           │                           │
-│  ┌────────▼───────┐  ┌────────────┐   │
-│  │ Coordinator 1  │  │    Redis   │   │
-│  └────────────────┘  └──────┬─────┘   │
-│                             │         │
-│  ┌────────────────┐         │         │
-│  │ Coordinator 2  ◄─────────┘         │
-│  └────────────────┘                   │
-│                                       │
-│  ┌────────────────┐                   │
-│  │ Coordinator 3  │                   │
-│  └────────────────┘                   │
-│                                       │
-└───────────────────────────────────────┘
+#### `POST /transaction`
+No-op. The coordinator discovers transactions itself via on-chain monitoring; party submissions are ignored. Returns `{ "Ok": null }`.
+
+#### `POST /transaction/status`
+Update the status of a transaction. Called by TSS parties after completing or failing a signing attempt.
+
+**Request body:**
+```json
+{
+  "txId": "string",
+  "status": 2,
+  "receiptId": "string",
+  "reason": "string",
+  "party": 1
+}
 ```
 
-## Security Considerations
+- For `status = 2` (COMPLETED): the coordinator verifies the `receiptId` on-chain before accepting.
+- A COMPLETED transaction cannot be downgraded to FAILED.
 
-- JWT tokens are used for authentication
-- API keys are used for initial registration
-- All communications should be over HTTPS in production
-- Redis should be password-protected in production
-- Docker containers run as non-root users
-- Rate limiting is applied to all endpoints
+---
 
-## Production Deployment
+### Timestamp consensus
 
-For production, you should:
+#### `POST /future-timestamp`
+First-write-wins timestamp agreement. The first party to submit a timestamp for a given key wins; subsequent parties receive the already-set value. Used to coordinate transaction timing across parties.
 
-1. Use a managed Redis service with proper security
-2. Set secure values for JWT_SECRET and API_KEY
-3. Configure proper SSL termination in NGINX
-4. Set up monitoring and alerts
-5. Implement backup and disaster recovery procedures
+**Request:** `{ "key": string, "value": string }` (value = timestamp as string)
+**Response:** `{ "timestamp": number }`
+
+---
+
+### Notifications
+
+#### `POST /notify-bridgeout`
+Triggers an immediate BridgedOut scan for the specified chain, bypassing the 60-second polling interval. Intended to be called by external clients (e.g. a UI or relayer) when they observe a `BridgedOut` event on-chain and want faster pickup without waiting for the next scheduled poll.
+
+Includes per-chain throttling: if called within 5 seconds of a recent poll, the scan is deferred rather than dropped, ensuring no event is silently missed.
+
+**Request:** `{ "chainId": number }`
+**Response:** `{ "Ok": "triggered" | "queued" | "cooldown" }`
+
+---
+
+## Data Model
+
+```
+Transaction {
+  txId:         string   -- normalized 64-char hex
+  sender:       string   -- lowercase Ethereum address
+  value:        string   -- amount (as string)
+  type:         number   -- 0=BRIDGE_IN, 1=BRIDGE_OUT, 2=BRIDGE_VAULT
+  txTimestamp:  number   -- Unix ms timestamp of the source event
+  chainId:      number   -- source chain ID (0 = Liberdus)
+  status:       number   -- 0=PENDING, 1=PROCESSING, 2=COMPLETED, 3=FAILED
+  receiptId:    string   -- on-chain receipt/tx hash after completion
+  reason:       string?  -- failure reason if FAILED
+  createdAt:    string   -- ISO timestamp
+  updatedAt:    string   -- ISO timestamp
+}
+```
+
+Transactions are stored in `transactions.sqlite` in the coordinator working directory. Monitor state (last scanned block per chain, last Liberdus timestamp) is persisted to `block_state.json`.
+
+## Project Structure
+
+```
+coordinator/
+  src/
+    server.ts          -- entry point, startup sequence, schedulers
+    routes.ts          -- all Express route handlers
+    auth.ts            -- Shardus Crypto request verification middleware
+    config.ts          -- chain-config.json loader
+    verification.ts    -- on-chain receipt verification for COMPLETED status
+    monitor/
+      ethereum.ts      -- BridgedOut/BridgedIn queryFilter scanning
+      liberdus.ts      -- Liberdus collector API polling
+      state.ts         -- monitor state load/save (block_state.json)
+    storage/
+      transactiondb.ts -- SQLite transaction CRUD
+      sqliteManager.ts -- SQLite wrapper
+    utils/
+      scheduler.ts     -- drift-resistant interval scheduler
+      transformAddress.ts
+      transformTxId.ts
+    lib/
+      httpProviderHelper.ts
+      rpcUrls.ts
+  allowed-tss-signers.json   -- whitelisted party public keys (auth)
+  package.json
+  tsconfig.json
+```

--- a/scripts/generate-keypairs.js
+++ b/scripts/generate-keypairs.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * generate-keypairs.js
+ *
+ * Generates Shardus Crypto (Ed25519) keypairs for TSS party nodes and saves
+ * them to keystores/tss_signer_keypair_party_N.json.
+ *
+ * Usage:
+ *   node scripts/generate-keypairs.js [--parties N] [--party P] [--force]
+ *
+ * Options:
+ *   --parties N   Number of parties to generate keypairs for (default: 5)
+ *   --party P     Generate a keypair for a single party P only (1-indexed)
+ *   --force       Overwrite existing keypair files (default: skip existing)
+ *
+ * After running, copy the printed public keys into:
+ *   coordinator/allowed-tss-signers.json  (when enableShardusCryptoAuth = true)
+ */
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const crypto = require('@shardus/crypto-utils')
+
+// -------------------------------------------------------------------------
+// CLI argument parsing
+// -------------------------------------------------------------------------
+const args = process.argv.slice(2)
+
+function getArgValue(flag) {
+  const idx = args.indexOf(flag)
+  if (idx === -1 || idx + 1 >= args.length) return null
+  return args[idx + 1]
+}
+
+const force = args.includes('--force')
+const partiesArg = getArgValue('--parties')
+const partyArg = getArgValue('--party')
+
+const numParties = partiesArg ? parseInt(partiesArg, 10) : 5
+if (isNaN(numParties) || numParties < 1) {
+  console.error('--parties must be a positive integer')
+  process.exit(1)
+}
+
+let partyIndices
+if (partyArg !== null) {
+  const p = parseInt(partyArg, 10)
+  if (isNaN(p) || p < 1) {
+    console.error('--party must be a positive integer')
+    process.exit(1)
+  }
+  partyIndices = [p]
+} else {
+  partyIndices = Array.from({ length: numParties }, (_, i) => i + 1)
+}
+
+// -------------------------------------------------------------------------
+// Main
+// -------------------------------------------------------------------------
+const keystoresDir = path.resolve(__dirname, '../keystores')
+fs.mkdirSync(keystoresDir, { recursive: true })
+
+const generatedPublicKeys = []
+
+for (const partyIdx of partyIndices) {
+  const filePath = path.join(keystoresDir, `tss_signer_keypair_party_${partyIdx}.json`)
+
+  if (fs.existsSync(filePath) && !force) {
+    const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    if (existing.publicKey && existing.secretKey) {
+      console.log(`[party ${partyIdx}] Keypair already exists — skipping (use --force to overwrite)`)
+      console.log(`             publicKey: ${existing.publicKey}`)
+      generatedPublicKeys.push(existing.publicKey)
+      continue
+    }
+  }
+
+  const { publicKey, secretKey } = crypto.generateKeypair()
+  const keypair = { publicKey, secretKey }
+
+  fs.writeFileSync(filePath, JSON.stringify(keypair, null, 2) + '\n', 'utf8')
+  console.log(`[party ${partyIdx}] Keypair written to ${filePath}`)
+  console.log(`             publicKey: ${publicKey}`)
+  generatedPublicKeys.push(publicKey)
+}
+
+// -------------------------------------------------------------------------
+// Print allowed-tss-signers.json snippet
+// -------------------------------------------------------------------------
+console.log('\n--- coordinator/allowed-tss-signers.json ---')
+console.log(JSON.stringify({ allowedTSSSigners: generatedPublicKeys }, null, 2))
+console.log('')
+console.log('Copy the block above into coordinator/allowed-tss-signers.json')
+console.log('and set "enableShardusCryptoAuth": true in chain-config.json to enable auth.')


### PR DESCRIPTION
- Root README: replace stale upstream library description with accurate Liberdus bridge signer overview — architecture diagram, setup steps, PM2 commands, bridge transaction flow, and key file reference
- Coordinator README: replace fictional Redis/JWT/Nginx/Docker content with accurate API reference (all 8 endpoints), startup sync sequence, auth setup, SQLite data model, and project structure
- Both READMEs: correct architecture — coordinator owns all on-chain monitoring (BridgedOut/BridgedIn/Liberdus); TSS parties poll coordinator every 10s, verify txs on-chain, then sign and submit
- Add TSS → Coordinator auth section: enableShardusCryptoAuth flag, Ed25519 keypair setup, env var overrides, signed request envelope
- Add scripts/generate-keypairs.js: generates Shardus Crypto Ed25519 keypairs for all 5 parties, writes keystores/tss_signer_keypair_party_N.json, prints ready-to-paste allowed-tss-signers.json block; supports --parties N, --party P, --force flags
- Add upstream attribution to EigenLabs @ieigen/tss-wasm