### PR TITLE
Feat/receipt timestamp field

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ Right now there are three TSS execution routes:
 2. TSS parties poll the paired observer every 10s for unprocessed transactions
 3. Each party independently queues the pending transaction from its local observer
 4. Parties sign through the native BNB TSS flow
-5. Winning party broadcasts the signed tx to Liberdus and updates local status
+5. Winning party broadcasts the signed tx to Liberdus and sets status to SUBMITTED with `receiptTimestamp`
 6. Winning party gossips Liberdus submission (`txId`, `receiptId`, `sourceChainId`) to peer observers via `/bridgein/liberdus/submitted` so peers can mark the source tx as SUBMITTED early (`txId` is source `bridgeOut` tx id, `receiptId` is destination `bridgeIn` tx id)
+7. Observer detects the delivery receipt from the Liberdus collector API and reconciles the final status (COMPLETED/FAILED/REVERTED); parties do not retry once `receiptTimestamp` is set
 
 **Liberdus -> EVM BridgeIn (Coin-to-Token):**
 1. Observer polls the Liberdus collector API for bridge transfers and saves them as PENDING

--- a/observer/index.ts
+++ b/observer/index.ts
@@ -361,7 +361,7 @@ app.post("/bridgein/evm/submitted", (req, res) => {
         TransactionDB.TransactionStatus.SUBMITTED,
         payload.receiptId,
         toEthereumAddress(destinationChain.tssSenderAddress),
-        payload.nonce,
+        { type: "nonce", value: payload.nonce },
         null,
       );
       console.log(
@@ -434,7 +434,7 @@ app.post("/bridgein/liberdus/submitted", (req, res) => {
         TransactionDB.TransactionStatus.SUBMITTED,
         payload.receiptId,
         toEthereumAddress(sourceChain.tssSenderAddress),
-        payload.txTimestamp,
+        { type: "receiptTimestamp", value: payload.txTimestamp },
         null,
       );
       console.log(

--- a/observer/monitor/ethereum.ts
+++ b/observer/monitor/ethereum.ts
@@ -426,7 +426,7 @@ export async function monitorEthereumBridgeInQueryFilter(
               successStatus,
               normalizeTxId(event.transactionHash),
               txTssSender as string,  // null falls back to current.tssSender in DB
-              txNonce as number,       // null falls back to current.nonce in DB
+              txNonce == null ? null : { type: "nonce", value: txNonce },
               null,
             );
             if (result === "ok") {
@@ -669,7 +669,7 @@ export async function monitorFailedBridgeIns(targetChainId?: number): Promise<bo
                 status,
                 tx.hash,
                 tssSender,
-                tx.nonce,
+                { type: "nonce", value: tx.nonce },
                 null,
               );
               pendingMissingNonces.delete(tx.nonce);

--- a/observer/monitor/liberdus.ts
+++ b/observer/monitor/liberdus.ts
@@ -1,14 +1,12 @@
 import { ethers } from "ethers";
 import axios from "axios";
 import * as TransactionDB from "../../shared/storage/transactiondb";
-import { chainConfigsRaw, getChainConfigById, paramsConfigRaw } from "../../shared/config";
+import { ChainConfig, chainConfigsRaw, getChainConfigById, paramsConfigRaw } from "../../shared/config";
 import { getCachedPeerObserverUrls } from "../../shared/utils/observerPeers";
 import { toEthereumAddress, toShardusAddress } from "../../shared/utils/transformAddress";
 import { normalizeTxId } from "../../shared/utils/transformTxId";
 import { observerChainRpc } from "../chainRpc";
 import { monitorState, saveMonitorState } from "./state";
-
-const PEER_TX_LOOKUP_TIMEOUT_MS = 4_000;
 
 const BRIDGE_OUT_EVENT_ABI =
   "event BridgedOut(address indexed from, uint256 amount, address indexed targetAddress, uint256 indexed chainId, uint256 timestamp)";
@@ -23,17 +21,21 @@ type ParsedLiberdusBridgeTxBase = {
 
 type ParsedLiberdusBridgeTx =
   | (ParsedLiberdusBridgeTxBase & {
-      txType: TransactionDB.TransactionType.BRIDGE_IN;
-      txId: string;
-    })
+    txType: TransactionDB.TransactionType.BRIDGE_IN;
+    txId: string;
+  })
   | (ParsedLiberdusBridgeTxBase & {
-      txType: TransactionDB.TransactionType.BRIDGE_OUT;
-      receiptId: string;
-    });
+    txType: TransactionDB.TransactionType.BRIDGE_OUT;
+    receiptId: string;
+  });
 
 type VerificationResult = { ok: boolean; reason?: string };
+type ObservationVerification = VerificationResult & {
+  finalStatus?: TransactionDB.TransactionStatus;
+};
 
-function isTerminalStatus(status: TransactionDB.TransactionStatus): boolean {
+
+function isFinalizedStatus(status: TransactionDB.TransactionStatus): boolean {
   return (
     status === TransactionDB.TransactionStatus.COMPLETED ||
     status === TransactionDB.TransactionStatus.FAILED ||
@@ -56,7 +58,8 @@ export async function monitorLiberdusTransactions(): Promise<void> {
       chainConfigsRaw.supportedChains
     )) {
       const chainId = parseInt(chainIdStr);
-      const { bridgeAddress } = chainConfig as any;
+      const { tssSenderAddress } = chainConfig as ChainConfig;
+      const bridgeAddress = toShardusAddress(tssSenderAddress);
 
       let page = 1;
       while (true) {
@@ -118,13 +121,81 @@ export async function monitorLiberdusTransactions(): Promise<void> {
             );
           } else {
             const { receiptId, status, txTimestamp } = parsed;
-            const reconciled = await reconcileObservedLiberdusBridgeOut(receiptId, status, txTimestamp);
-            if (!reconciled) {
-              console.log(
-                `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${
-                  TransactionDB.getStatusLabel(status)
-                } (sourceChain txId not found locally or from verified peers)`
+
+            const existingTx = TransactionDB.getTransactionByReceiptId(receiptId);
+            if (existingTx) {
+              const expectedStatus = getFinalizedTxStatus(existingTx.type, status);
+              const isFinalized = isFinalizedStatus(existingTx.status);
+              const tssSenderMismatch =
+                existingTx.tssSender &&
+                toEthereumAddress(existingTx.tssSender ?? "") !==
+                toEthereumAddress(tssSenderAddress);
+              const statusMismatch =
+                existingTx.status && existingTx.status !== expectedStatus;
+              const receiptIdMismatch =
+                existingTx.receiptId && existingTx.receiptId !== receiptId;
+              const receiptTimestampMismatch =
+                existingTx.receiptTimestamp &&
+                existingTx.receiptTimestamp !== txTimestamp;
+              if (isFinalized) {
+                // Already settled — verify the observed delivery matches what we recorded.
+                if (statusMismatch) {
+                  console.warn(
+                    `[observer/liberdus] Status mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${TransactionDB.getStatusLabel(existingTx.status)} expected=${TransactionDB.getStatusLabel(expectedStatus)}`,
+                  );
+                }
+                if (receiptIdMismatch) {
+                  console.warn(
+                    `[observer/liberdus] ReceiptId mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${existingTx.receiptId} expected=${receiptId}`,
+                  );
+                }
+                if (receiptTimestampMismatch) {
+                  console.warn(
+                    `[observer/liberdus] ReceiptTimestamp mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${existingTx.receiptTimestamp} expected=${txTimestamp}`,
+                  );
+                }
+                if (!tssSenderMismatch && !statusMismatch && !receiptIdMismatch && !receiptTimestampMismatch) {
+                  console.log(
+                    `[observer/liberdus] Already saved ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId} status=${TransactionDB.getStatusLabel(existingTx.status)}`,
+                  );
+                  continue;
+                }
+              }
+              const result = TransactionDB.updateTransactionStatus(
+                existingTx.txId,
+                expectedStatus,
+                receiptId,
+                toEthereumAddress(tssSenderAddress),
+                { type: "receiptTimestamp", value: txTimestamp },
+                null,
               );
+              if (result === "ok") {
+                console.log(
+                  `[observer/liberdus] Updated status for existing txId=${existingTx.txId} to ${TransactionDB.getStatusLabel(expectedStatus)}`,
+                );
+              } else {
+                console.warn(
+                  `[observer/liberdus] Failed to update status for existing txId=${existingTx.txId} to ${TransactionDB.getStatusLabel(expectedStatus)}: ${result}`,
+                );
+              }
+            } else {
+              console.warn(
+                `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${TransactionDB.getStatusLabel(
+                  status,
+                )} (sourceChain txId not found locally)`,
+              )
+              const reconciled = await reconcileObservedLiberdusBridgeOut(
+                receiptId,
+                status,
+                txTimestamp,
+              );
+              if (!reconciled) {
+                console.log(
+                  `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${TransactionDB.getStatusLabel(
+                    status,
+                  )} (sourceChain txId not found locally or from verified peers)`,
+                );
+              }
             }
           }
         }
@@ -193,14 +264,14 @@ async function fetchPeerTransactionByReceiptId(receiptId: string): Promise<Trans
     try {
       const response = await axios.get(`${baseUrl}/transaction`, {
         params: { receiptId },
-        timeout: PEER_TX_LOOKUP_TIMEOUT_MS,
+        timeout: 3_000,
       });
       const txs = response.data?.Ok?.transactions;
       if (Array.isArray(txs) && txs.length > 0) {
         const tx = txs[0] as TransactionDB.Transaction;
-        if (!isTerminalStatus(tx.status)) {
+        if (!isFinalizedStatus(tx.status)) {
           console.warn(
-            `[observer/liberdus] Peer tx found for receiptId=${receiptId} but status=${TransactionDB.getStatusLabel(tx.status)} is not terminal`,
+            `[observer/liberdus] Peer tx found for receiptId=${receiptId} but status=${TransactionDB.getStatusLabel(tx.status)} is not finalized`,
           );
           continue;
         }
@@ -213,7 +284,9 @@ async function fetchPeerTransactionByReceiptId(receiptId: string): Promise<Trans
   return null;
 }
 
-async function verifyEvmBridgeOutSourceTx(tx: TransactionDB.Transaction): Promise<VerificationResult> {
+async function verifyEvmBridgeOutSourceTx(
+  tx: TransactionDB.Transaction,
+): Promise<VerificationResult> {
   const sourceChain = getChainConfigById(chainConfigsRaw, tx.chainId);
   if (!sourceChain?.contractAddress) {
     return { ok: false, reason: "missing_source_chain_contract" };
@@ -268,6 +341,25 @@ async function verifyEvmBridgeOutSourceTx(tx: TransactionDB.Transaction): Promis
   }
 }
 
+async function retryFetch<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  delayMs = 500,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) {
+        await new Promise((r) => setTimeout(r, delayMs * (attempt + 1)));
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function verifyLiberdusTx(
   txId: string,
   expected: { success: boolean; from: string; amount: string },
@@ -276,9 +368,9 @@ async function verifyLiberdusTx(
     process.env.PROXY_SERVER_HOST || chainConfigsRaw.proxyServerHost || "http://127.0.0.1:3030";
 
   try {
-    const response = await axios.get(`${proxyServerHost}/transaction/${txId}`, {
-      timeout: 10_000,
-    });
+    const response = await retryFetch(() =>
+      axios.get(`${proxyServerHost}/transaction/${txId}`, { timeout: 5_000 }),
+    );
     const tx = response.data?.transaction;
     if (!tx) return { ok: false, reason: "missing_liberdus_tx" };
     const success = tx.success;
@@ -323,74 +415,30 @@ async function verifyLiberdusTx(
   }
 }
 
-function terminalStatusFromObservation(
-  tx: TransactionDB.Transaction,
+function getFinalizedTxStatus(
+  txType: TransactionDB.TransactionType,
   observedStatus: TransactionDB.TransactionStatus,
 ): TransactionDB.TransactionStatus {
-  if (isTerminalStatus(tx.status)) {
-    return tx.status;
-  }
-  if (
-    tx.type === TransactionDB.TransactionType.BRIDGE_IN &&
+  // BRIDGE_IN + observed COMPLETED means a successful refund, stored as REVERTED.
+  return txType === TransactionDB.TransactionType.BRIDGE_IN &&
     observedStatus === TransactionDB.TransactionStatus.COMPLETED
-  ) {
-    return TransactionDB.TransactionStatus.REVERTED;
-  }
-  return observedStatus;
+    ? TransactionDB.TransactionStatus.REVERTED
+    : observedStatus;
 }
 
-function isSupportedObservedTx(tx: TransactionDB.Transaction): boolean {
+function isReconcilableTxType(tx: TransactionDB.Transaction): boolean {
   return (
     tx.type === TransactionDB.TransactionType.BRIDGE_OUT ||
     tx.type === TransactionDB.TransactionType.BRIDGE_IN
   );
 }
 
-async function verifyObservedLiberdusReceipt(
+async function verifySourceBridgeTx(
   tx: TransactionDB.Transaction,
-  observedReceiptId: string,
-  finalStatus: TransactionDB.TransactionStatus,
-): Promise<VerificationResult> {
-  const liberdusBridgeAddress = getChainConfigById(chainConfigsRaw, tx.chainId)?.bridgeAddress;
-  if (!liberdusBridgeAddress) {
-    return { ok: false, reason: "missing_liberdus_bridge_address" };
-  }
-
-  const receiptVerification = await verifyLiberdusTx(observedReceiptId, {
-    success: finalStatus !== TransactionDB.TransactionStatus.FAILED,
-    from: liberdusBridgeAddress,
-    amount: tx.value,
-  });
-  if (!receiptVerification.ok) return receiptVerification;
-
-  if (tx.type === TransactionDB.TransactionType.BRIDGE_OUT) {
-    return verifyEvmBridgeOutSourceTx(tx);
-  }
-
-  if (
-    tx.type === TransactionDB.TransactionType.BRIDGE_IN &&
-    (
-      finalStatus === TransactionDB.TransactionStatus.REVERTED ||
-      finalStatus === TransactionDB.TransactionStatus.FAILED
-    )
-  ) {
-    return verifyLiberdusTx(tx.txId, {
-      success: true,
-      from: tx.sender,
-      amount: tx.value,
-    });
-  }
-
-  return { ok: false, reason: "unsupported_tx_type_or_status_for_liberdus_receipt" };
-}
-
-async function verifyObservedTx(
-  tx: TransactionDB.Transaction,
-  receiptId: string,
   observedStatus: TransactionDB.TransactionStatus,
   receiptTxTimestamp: number,
-): Promise<{ ok: boolean; finalStatus?: TransactionDB.TransactionStatus; reason?: string }> {
-  if (!isSupportedObservedTx(tx)) {
+): Promise<ObservationVerification> {
+  if (!isReconcilableTxType(tx)) {
     return { ok: false, reason: `unsupported_tx_type_${tx.type}` };
   }
   const chainConfig = getChainConfigById(chainConfigsRaw, tx.chainId);
@@ -407,66 +455,33 @@ async function verifyObservedTx(
     return { ok: false, reason: "receiptTimestamp_mismatch" };
   }
 
-  const finalStatus = terminalStatusFromObservation(tx, observedStatus);
-  const verification = await verifyObservedLiberdusReceipt(
-    tx,
-    receiptId,
-    finalStatus,
-  );
-  return verification.ok
-    ? { ok: true, finalStatus }
-    : { ok: false, reason: verification.reason };
-}
+  const expectedStatus = getFinalizedTxStatus(tx.type, observedStatus);
+  if (tx.status !== expectedStatus) {
+    return { ok: false, reason: `observed_status_mismatch(expected=${expectedStatus}, found=${tx.status})` };
+  }
+  const finalStatus = expectedStatus;
 
-function updateObservedTransactionStatus(
-  tx: TransactionDB.Transaction,
-  receiptId: string,
-  status: TransactionDB.TransactionStatus,
-  receiptTxTimestamp: number,
-): boolean {
-  const chainConfig = getChainConfigById(chainConfigsRaw, tx.chainId);
-  if (!chainConfig?.tssSenderAddress) {
-    console.warn(`[observer/liberdus] Cannot update ${TransactionDB.TransactionType[tx.type]} txId=${tx.txId}: missing chain tssSenderAddress`);
-    return false;
+  if (tx.type === TransactionDB.TransactionType.BRIDGE_OUT) {
+    // Verify the original EVM source tx that triggered this bridge-out delivery.
+    const evmVerification = await verifyEvmBridgeOutSourceTx(tx);
+    return evmVerification.ok ? { ok: true, finalStatus } : evmVerification;
   }
 
-  const result = TransactionDB.updateTransactionStatus(
-    tx.txId,
-    status,
-    receiptId,
-    toEthereumAddress(chainConfig.tssSenderAddress),
-    { type: "receiptTimestamp", value: receiptTxTimestamp },
-    tx.reason ?? null,
-  );
-  console.log(
-    `[observer/liberdus] Updated ${TransactionDB.TransactionType[tx.type]} txId=${tx.txId} receiptId=${receiptId} -> ${TransactionDB.getStatusLabel(status)} result=${result}`,
-  );
-  return result !== "not_found";
+  // BRIDGE_IN: delivery is a refund — verify the original Liberdus source tx (user → bridge).
+  const sourceVerification = await verifyLiberdusTx(tx.txId, {
+    success: true,
+    from: tx.sender,
+    amount: tx.value,
+  });
+  return sourceVerification.ok ? { ok: true, finalStatus } : sourceVerification;
 }
 
+
 async function reconcileObservedLiberdusBridgeOut(
-  receiptId: string,
+  normalizedReceiptId: string,
   status: TransactionDB.TransactionStatus,
   receiptTxTimestamp: number,
 ): Promise<boolean> {
-  const normalizedReceiptId = normalizeTxId(receiptId);
-
-  const localTx = TransactionDB.getTransactionByReceiptId(normalizedReceiptId);
-  if (localTx) {
-    const verified = await verifyObservedTx(localTx, normalizedReceiptId, status, receiptTxTimestamp);
-    if (!verified.ok || verified.finalStatus == null) {
-      console.warn(
-        `[observer/liberdus] Local tx found for receiptId=${normalizedReceiptId} but verification failed (${verified.reason})`,
-      );
-      if (isTerminalStatus(localTx.status)) return false;
-      console.warn(
-        `[observer/liberdus] Local tx for receiptId=${normalizedReceiptId} is non-terminal; trying verified peer backfill`,
-      );
-    } else {
-      return updateObservedTransactionStatus(localTx, normalizedReceiptId, verified.finalStatus, receiptTxTimestamp);
-    }
-  }
-
   const peerTx = await fetchPeerTransactionByReceiptId(normalizedReceiptId);
   if (!peerTx) return false;
 
@@ -487,7 +502,11 @@ async function reconcileObservedLiberdusBridgeOut(
     return false;
   }
 
-  const verified = await verifyObservedTx(peerTx, normalizedReceiptId, status, receiptTxTimestamp);
+  const verified = await verifySourceBridgeTx(
+    peerTx,
+    status,
+    receiptTxTimestamp,
+  );
   if (!verified.ok || verified.finalStatus == null) {
     console.warn(
       `[observer/liberdus] Peer tx found for receiptId=${normalizedReceiptId} but verification failed (${verified.reason})`,
@@ -495,13 +514,36 @@ async function reconcileObservedLiberdusBridgeOut(
     return false;
   }
 
-  const existingByTxId = TransactionDB.getTransactionById(normalizeTxId(peerTx.txId));
+  const normalizedTxId = normalizeTxId(peerTx.txId);
+  const existingByTxId = TransactionDB.getTransactionById(normalizedTxId);
   if (existingByTxId) {
-    return updateObservedTransactionStatus(existingByTxId, normalizedReceiptId, verified.finalStatus, receiptTxTimestamp);
+    const chainConfig = getChainConfigById(chainConfigsRaw, existingByTxId.chainId);
+    if (!chainConfig?.tssSenderAddress) {
+      console.warn(`[observer/liberdus] Cannot update ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId}: missing chain tssSenderAddress`);
+      return false;
+    }
+    const result = TransactionDB.updateTransactionStatus(
+      existingByTxId.txId,
+      verified.finalStatus,
+      normalizedReceiptId,
+      toEthereumAddress(chainConfig.tssSenderAddress),
+      { type: "receiptTimestamp", value: receiptTxTimestamp },
+      existingByTxId.reason ?? null,
+    );
+    if (result === "ok") {
+      console.log(
+        `[observer/liberdus] Updated ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId} receiptId=${normalizedReceiptId} -> ${TransactionDB.getStatusLabel(verified.finalStatus)}`,
+      );
+    } else {
+      console.warn(
+        `[observer/liberdus] Failed to update ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId} -> ${TransactionDB.getStatusLabel(verified.finalStatus)}: ${result}`,
+      );
+    }
+    return result !== "not_found";
   }
 
   const reconciledTx: TransactionDB.Transaction = {
-    txId: normalizeTxId(peerTx.txId),
+    txId: normalizedTxId,
     sender: peerTx.sender,
     value: peerTx.value,
     type: peerTx.type,

--- a/observer/monitor/liberdus.ts
+++ b/observer/monitor/liberdus.ts
@@ -400,11 +400,11 @@ async function verifyObservedTx(
   if (toEthereumAddress(tx.tssSender ?? "") !== toEthereumAddress(chainConfig.tssSenderAddress)) {
     return { ok: false, reason: "tssSender_mismatch" };
   }
-  if (tx.nonce !== receiptTxTimestamp) {
+  if (tx.receiptTimestamp !== receiptTxTimestamp) {
     console.warn(
-      `[observer/liberdus] nonce_mismatch txId=${tx.txId} tx.nonce=${tx.nonce} receiptTxTimestamp=${receiptTxTimestamp}`,
+      `[observer/liberdus] receiptTimestamp_mismatch txId=${tx.txId} tx.receiptTimestamp=${tx.receiptTimestamp} receiptTxTimestamp=${receiptTxTimestamp}`,
     );
-    return { ok: false, reason: "nonce_mismatch" };
+    return { ok: false, reason: "receiptTimestamp_mismatch" };
   }
 
   const finalStatus = terminalStatusFromObservation(tx, observedStatus);
@@ -435,7 +435,7 @@ function updateObservedTransactionStatus(
     status,
     receiptId,
     toEthereumAddress(chainConfig.tssSenderAddress),
-    receiptTxTimestamp,
+    { type: "receiptTimestamp", value: receiptTxTimestamp },
     tx.reason ?? null,
   );
   console.log(
@@ -510,7 +510,7 @@ async function reconcileObservedLiberdusBridgeOut(
     receiptId: normalizedReceiptId,
     status: verified.finalStatus,
     tssSender: toEthereumAddress(peerTx.tssSender!),
-    nonce: receiptTxTimestamp,
+    receiptTimestamp: receiptTxTimestamp,
     reason: peerTx.reason ?? null,
     executionHistory: peerTx.executionHistory ?? "{}",
   };

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -594,7 +594,7 @@ function updateTxStatusInLocalDB(
 async function pollPendingTransactionsFromLocalDB(): Promise<void> {
   if (verboseLogs) console.log('Polling pending transactions from local DB...', new Date().toISOString())
   try {
-    const dbTxs = TransactionDB.getTransactionsByPage(10, 0, { unprocessed: true })
+    const dbTxs = TransactionDB.getTransactionsByPage(10, 0, { unprocessed: true, partyRetryable: true })
     const transactions: Transaction[] = dbTxs
       .slice()
       .sort((a, b) => a.txTimestamp - b.txTimestamp)
@@ -678,17 +678,7 @@ async function pollPendingTransactionsFromLocalDB(): Promise<void> {
 }
 
 
-function checkTxStatusFromLocalDB(txId: string): TransactionStatus | null {
-  try {
-    const normalizedTxId = normalizeTxId(txId)
-    const tx = TransactionDB.getTransactionById(normalizedTxId)
-    if (!tx) return null
-    return tx.status
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    throw new Error(`[checkTxStatus] DB read failed for ${txId}: ${errorMessage}`)
-  }
-}
+
 
 // ---------------------------------------------------------------------------
 // Nonce manager — tracks the expected next EVM nonce per chain per sender.
@@ -766,7 +756,7 @@ const signedTxCache: Map<string, { signedTx: string; txHash: string; nonce: numb
 // ---------------------------------------------------------------------------
 function reconcileTxStatusWithLocalDB(
   txId: string,
-  context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit',
+  context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit' | 'timeout',
 // 'submitted' is Liberdus-only: EVM txs in SUBMITTED/INCOMPLETED are retried by the party.
 ): null | 'submitted' | 'completed' | 'failed' | 'reverted' {
   if (DEBUG_SKIP_TX_STATUS_CHECK) return null
@@ -2478,8 +2468,12 @@ async function main(): Promise<void> {
           console.warn('Transaction processing timed out', validTx.txId)
         }
 
-        const finalStatus = checkTxStatusFromLocalDB(validTx.txId)
-        if (finalStatus === TransactionStatus.COMPLETED) {
+        const dbStatus = reconcileTxStatusWithLocalDB(validTx.txId, 'timeout')
+        if (dbStatus === 'submitted') {
+          txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+          pendingTxQueueRemovalSet.add(txId)
+          console.log(`[${timeoutReason}] ${validTx.txId} already submitted to Liberdus`)
+        } else if (dbStatus === 'completed') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'completed' })
           pendingTxQueueRemovalSet.add(txId)
           // Another party submitted this tx — nonce was consumed, advance local tracker
@@ -2493,12 +2487,16 @@ async function main(): Promise<void> {
             incrementLocalNonce(nonceCacheChainId, nonceTssSender)
           }
           console.log(`[${timeoutReason}] ${validTx.txId} already COMPLETED in local DB`)
-        } else if (finalStatus === TransactionStatus.REVERTED) {
+        } else if (dbStatus === 'reverted') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'reverted' })
           pendingTxQueueRemovalSet.add(txId)
           console.log(`[${timeoutReason}] ${validTx.txId} already REVERTED in local DB`)
-        } else {
+        } else if (dbStatus === 'failed') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'failed' })
+          pendingTxQueueRemovalSet.add(txId)
+          console.warn(`[${timeoutReason}] ${validTx.txId} already FAILED in local DB`)
+        } else {
+          txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'incompleted' })
           appendToFailedTxsLogs(validTx, timeoutReason)
           console.warn(`[${timeoutReason}] ${validTx.txId} not completed in local DB`)
         }

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -73,7 +73,7 @@ interface TransactionQueueItem {
 
 interface TxQueueEntry {
   txTimestamp: number // milliseconds, from source-chain event/block time
-  status: 'pending' | 'processing' | 'completed' | 'incompleted' | 'failed' | 'reverted'
+  status: 'pending' | 'processing' | 'submitted' | 'completed' | 'incompleted' | 'failed' | 'reverted'
 }
 
 interface PartyInfo {
@@ -105,7 +105,7 @@ interface SignedTx {
   }
 }
 
-type ProcessOutcome = 'completed' | 'incompleted' | 'failed' | 'reverted' | 'skipped_db_completed' | 'skipped_db_failed' | 'skipped_db_reverted'
+type ProcessOutcome = 'completed' | 'incompleted' | 'failed' | 'reverted' | 'skipped_db_submitted' | 'skipped_db_completed' | 'skipped_db_failed' | 'skipped_db_reverted'
 
 // Receipt is polled only while remaining cooldown time exceeds (bridgeInCooldown - this value).
 // e.g. for a 60s cooldown: poll while remainingMs > 45s, skip receipt checks once < 45s remains —
@@ -767,12 +767,27 @@ const signedTxCache: Map<string, { signedTx: string; txHash: string; nonce: numb
 function reconcileTxStatusWithLocalDB(
   txId: string,
   context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit',
-): null | 'completed' | 'failed' | 'reverted' {
+// 'submitted' is Liberdus-only: EVM txs in SUBMITTED/INCOMPLETED are retried by the party.
+): null | 'submitted' | 'completed' | 'failed' | 'reverted' {
   if (DEBUG_SKIP_TX_STATUS_CHECK) return null
   try {
-    const status = checkTxStatusFromLocalDB(txId)
+    const normalizedTxId = normalizeTxId(txId)
+    const tx = TransactionDB.getTransactionById(normalizedTxId)
+    if (!tx) return null
+
+    const { status } = tx
+
+    // Liberdus txs (receiptTimestamp set) in SUBMITTED/INCOMPLETED have been delivered
+    // to the Liberdus network — the party should not retry them.
     if (
-      status == null ||
+      (status === TransactionStatus.SUBMITTED || status === TransactionStatus.INCOMPLETED) &&
+      tx.receiptTimestamp != null
+    ) {
+      console.log(`⏩ ${txId} already submitted to Liberdus (${context}), skipping`)
+      return 'submitted'
+    }
+
+    if (
       status === TransactionStatus.PENDING ||
       status === TransactionStatus.SUBMITTED ||
       status === TransactionStatus.INCOMPLETED
@@ -794,8 +809,9 @@ function reconcileTxStatusWithLocalDB(
 
 // Maps a reconcile skip status to the corresponding ProcessOutcome.
 function dbStatusToSkipOutcome(
-  status: 'completed' | 'failed' | 'reverted',
+  status: 'submitted' | 'completed' | 'failed' | 'reverted',
 ): ProcessOutcome {
+  if (status === 'submitted') return 'skipped_db_submitted'
   if (status === 'completed') return 'skipped_db_completed'
   if (status === 'reverted') return 'skipped_db_reverted'
   return 'skipped_db_failed'
@@ -2343,7 +2359,10 @@ async function main(): Promise<void> {
       const tssSender = validTx.type === 'vaultBridge'
         ? chainConfigs.secondaryChainConfig!.tssSenderAddress!
         : getChainConfigById(chainConfigs, validTx.chainId)!.tssSenderAddress!
-      if (preProcess === 'completed') {
+      if (preProcess === 'submitted') {
+        txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+        appendToFailedTxsLogs(validTx, 'already submitted to Liberdus at pre-process')
+      } else if (preProcess === 'completed') {
         syncLocalNonceFromDB(validTx.type, validTx.chainId, tssSender)
         txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'completed' })
       } else if (preProcess === 'failed') {
@@ -2434,6 +2453,11 @@ async function main(): Promise<void> {
         console.log(`Transaction ${validTx.txId} was already reverted in local DB during reconcile, skipping`)
         txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'reverted' })
         pendingTxQueueRemovalSet.add(txId)
+      } else if (outcome === 'skipped_db_submitted') {
+        console.log(`Transaction ${validTx.txId} was already submitted to Liberdus during reconcile, skipping`)
+        txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+        pendingTxQueueRemovalSet.add(txId)
+        appendToFailedTxsLogs(validTx, 'already submitted to Liberdus during reconcile')
       }
 
       // Check memory usage after successful transaction

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -555,7 +555,7 @@ function updateTxStatusInLocalDB(
   status: TransactionStatus,
   receiptId: string,
   tssSender: string,
-  nonce: number,
+  receiptRef: TransactionDB.TxReceiptRef,
   failedReason = '',
 ): ReturnType<typeof TransactionDB.updateTransactionStatus> {
   try {
@@ -569,7 +569,7 @@ function updateTxStatusInLocalDB(
       status,
       normalizedReceiptId,
       normalizedTssSender,
-      nonce,
+      receiptRef,
       failedReason || null,
     )
 
@@ -1135,7 +1135,7 @@ async function processCoinToToken(
   if (!await checkMaxBridgeAmount(chainState, value)) {
     const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(chainState.maxBridgeInAmount)}`
     console.error(`${reason} on ${targetChainName}`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce as number, reason)
+    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce as number), reason)
     pendingTxQueueRemovalSet.add(txId)
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, `max bridge amount check failed on ${targetChainName}`)
@@ -1184,7 +1184,7 @@ async function processCoinToToken(
     if (!await checkMaxBridgeAmount(chainState, value, true)) {
       const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(chainState.maxBridgeInAmount)}`
       console.error(`${reason} on ${targetChainName} (post-sign)`)
-      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce as number, reason)
+      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce as number), reason)
       pendingTxQueueRemovalSet.add(txId)
       signedTxCache.delete(normalizedTxId)
       const txData = processingTransactionIds.get(txId)
@@ -1197,13 +1197,13 @@ async function processCoinToToken(
       return cooldownResult.outcome
     }
     if (cooldownResult.receipt?.status === 1) {
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, senderNonce)
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
       return 'completed'
     } else if (cooldownResult.receipt?.status === 0) {
       console.log(`[nonce-guard] Cached tx failed on ${targetChainName}: ${cached.txHash}`)
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, senderNonce)
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
       return 'failed'
@@ -1218,7 +1218,7 @@ async function processCoinToToken(
         txId: cached.txHash,
         maxRetries: 3,
       })
-      updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, cached.txHash, tssSender, senderNonce, '')
+      updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
       await gossipBridgeIn('evm', {
         txId: normalizeTxId(txId),
         sourceChainId: 0,
@@ -1229,13 +1229,13 @@ async function processCoinToToken(
       }, n, observerUrl)
       const cachedReceipt = await getChainTransactionReceipt(targetChainId, cached.txHash)
       if (cachedReceipt?.status === 1) {
-        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, senderNonce)
+        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
         signedTxCache.delete(normalizedTxId)
         if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
         return 'completed'
       } else if (cachedReceipt?.status === 0) {
         console.log(`[nonce-guard] Cached tx failed on ${targetChainName}: ${cached.txHash}`)
-        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, senderNonce)
+        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
         signedTxCache.delete(normalizedTxId)
         if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
         return 'failed'
@@ -1309,7 +1309,7 @@ async function processCoinToToken(
   if (!await checkMaxBridgeAmount(chainState, value, true)) {
     const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(chainState.maxBridgeInAmount)}`
     console.error(`${reason} on ${targetChainName} (post-sign)`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce as number, reason)
+    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce as number), reason)
     pendingTxQueueRemovalSet.add(txId)
     signedTxCache.delete(normalizedTxId)
     const txData = processingTransactionIds.get(txId)
@@ -1329,7 +1329,7 @@ async function processCoinToToken(
         ? `Refund is successful - original tx ${txId} - refund ethereum tx ${txHash} on original source chain ${targetChainName}`
         : `Transaction is successful - liberdus tx ${txId} - ethereum tx ${txHash} on ${targetChainName}`,
     )
-    const updateResult = updateTxStatusInLocalDB(txId, finalStatus, txHash, tssSender, senderNonce, isRefund ? revertReason ?? '' : '')
+    const updateResult = updateTxStatusInLocalDB(txId, finalStatus, txHash, tssSender, TransactionDB.txNonce(senderNonce), isRefund ? revertReason ?? '' : '')
     signedTxCache.delete(normalizedTxId)
     if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
     return finalOutcome
@@ -1339,7 +1339,7 @@ async function processCoinToToken(
     )
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, `failed in execution on ${targetChainName}`)
-    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, senderNonce, '')
+    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
     signedTxCache.delete(normalizedTxId)
     if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
     return 'failed'
@@ -1369,7 +1369,7 @@ async function processCoinToToken(
   }
 
   if (res.success) {
-    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, txHash, tssSender, senderNonce, '')
+    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
     await gossipBridgeIn('evm', {
       txId: normalizeTxId(txId),
       sourceChainId: 0,
@@ -1402,7 +1402,7 @@ async function processCoinToToken(
           ? `Refund is successful - original tx ${txId} - refund ethereum tx ${txHash} on original source chain ${targetChainName}`
           : `Transaction is successful - liberdus tx ${txId} - ethereum tx ${txHash} on ${targetChainName}`,
       )
-      const updateResult = updateTxStatusInLocalDB(txId, finalStatus, txHash, tssSender, senderNonce, isRefund ? revertReason ?? '' : '')
+      const updateResult = updateTxStatusInLocalDB(txId, finalStatus, txHash, tssSender, TransactionDB.txNonce(senderNonce), isRefund ? revertReason ?? '' : '')
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)
       return finalOutcome
@@ -1412,7 +1412,7 @@ async function processCoinToToken(
       )
       const txData = processingTransactionIds.get(txId)
       if (txData) appendToFailedTxsLogs(txData, `failed in execution on ${targetChainName}`)
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, senderNonce, '')
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(targetChainId, tssSender)  // nonce consumed even on on-chain failure
       return 'failed'
@@ -1424,7 +1424,7 @@ async function processCoinToToken(
     )
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, res.reason ?? `send incompleted on ${targetChainName}`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, txHash, tssSender, senderNonce, res.reason as string)
+    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, txHash, tssSender, TransactionDB.txNonce(senderNonce), res.reason as string)
     pendingTxQueueRemovalSet.add(txId)
     // Don't increment nonce — tx may not have been broadcast/mined
     // signedTxCache is NOT cleared — we may want to rebroadcast on next attempt
@@ -1475,7 +1475,7 @@ async function processVaultBridge(
   if (!await checkMaxBridgeAmount(destChainState, value)) {
     const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(destChainState.maxBridgeInAmount)}`
     console.error(`${reason} on ${destChainName}`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce, reason)
+    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce), reason)
     pendingTxQueueRemovalSet.add(txId)
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, `max bridge amount check failed on ${destChainName}`)
@@ -1525,7 +1525,7 @@ async function processVaultBridge(
     if (!await checkMaxBridgeAmount(destChainState, value, true)) {
       const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(destChainState.maxBridgeInAmount)}`
       console.error(`${reason} on ${destChainName} (post-sign)`)
-      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce as number, reason)
+      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce as number), reason)
       pendingTxQueueRemovalSet.add(txId)
       signedTxCache.delete(normalizedTxId)
       const txData = processingTransactionIds.get(txId)
@@ -1538,13 +1538,13 @@ async function processVaultBridge(
       return cooldownResult.outcome
     }
     if (cooldownResult.receipt?.status === 1) {
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, senderNonce)
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
       return 'completed'
     } else if (cooldownResult.receipt?.status === 0) {
       console.log(`[nonce-guard] Cached tx failed on ${destChainName}: ${cached.txHash}`)
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, senderNonce)
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
       return 'failed'
@@ -1559,7 +1559,7 @@ async function processVaultBridge(
         txId: cached.txHash,
         maxRetries: 3,
       })
-      updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, cached.txHash, tssSender, senderNonce, '')
+      updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
       await gossipBridgeIn('evm', {
         txId: normalizeTxId(txId),
         sourceChainId,
@@ -1570,13 +1570,13 @@ async function processVaultBridge(
       }, n, observerUrl)
       const receipt = await getChainTransactionReceipt(destinationChainId, cached.txHash)
       if (receipt?.status === 1) {
-        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, senderNonce)
+        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
         signedTxCache.delete(normalizedTxId)
         if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
         return 'completed'
       } else if (receipt?.status === 0) {
         console.log(`[nonce-guard] Cached tx failed on ${destChainName}: ${cached.txHash}`)
-        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, senderNonce)
+        const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
         signedTxCache.delete(normalizedTxId)
         if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
         return 'failed'
@@ -1650,7 +1650,7 @@ async function processVaultBridge(
   if (!await checkMaxBridgeAmount(destChainState, value, true)) {
     const reason = `Amount ${ethersUtils.formatEther(value)} exceeds bridge-in limit ${ethersUtils.formatEther(destChainState.maxBridgeInAmount)}`
     console.error(`${reason} on ${destChainName} (post-sign)`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, senderNonce as number, reason)
+    updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, '', tssSender, TransactionDB.txNonce(senderNonce as number), reason)
     pendingTxQueueRemovalSet.add(txId)
     signedTxCache.delete(normalizedTxId)
     const txData = processingTransactionIds.get(txId)
@@ -1666,7 +1666,7 @@ async function processVaultBridge(
     console.log(
       `EVM-to-EVM transaction successful - source tx ${txId} on ${sourceChainName} - dest tx ${txHash} on ${destChainName}`,
     )
-    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, txHash, tssSender, senderNonce, '')
+    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
     signedTxCache.delete(normalizedTxId)
     if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
     return 'completed'
@@ -1676,7 +1676,7 @@ async function processVaultBridge(
     )
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, `failed in execution on ${destChainName}`)
-    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, senderNonce, '')
+    const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
     signedTxCache.delete(normalizedTxId)
     if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
     return 'failed'
@@ -1708,7 +1708,7 @@ async function processVaultBridge(
   }
 
   if (res.success) {
-    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, txHash, tssSender, senderNonce, '')
+    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
     await gossipBridgeIn('evm', {
       txId: normalizeTxId(txId),
       sourceChainId,
@@ -1737,7 +1737,7 @@ async function processVaultBridge(
       console.log(
         `EVM-to-EVM transaction successful - source tx ${txId} on ${sourceChainName} - dest tx ${txHash} on ${destChainName}`,
       )
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, txHash, tssSender, senderNonce, '')
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)
       return 'completed'
@@ -1747,7 +1747,7 @@ async function processVaultBridge(
       )
       const txData = processingTransactionIds.get(txId)
       if (txData) appendToFailedTxsLogs(txData, `failed in execution on ${destChainName}`)
-      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, senderNonce, '')
+      const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, txHash, tssSender, TransactionDB.txNonce(senderNonce), '')
       signedTxCache.delete(normalizedTxId)
       if (updateResult === 'ok') incrementLocalNonce(destinationChainId, tssSender)  // nonce consumed even on on-chain failure
       return 'failed'
@@ -1759,7 +1759,7 @@ async function processVaultBridge(
     )
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, res.reason ?? `send incompleted on ${destChainName}`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, txHash, tssSender, senderNonce, res.reason as string)
+    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, txHash, tssSender, TransactionDB.txNonce(senderNonce), res.reason as string)
     pendingTxQueueRemovalSet.add(txId)
     // Don't increment nonce — tx may not have been broadcast/mined
     // signedTxCache is NOT cleared — we may want to rebroadcast on next attempt
@@ -1876,16 +1876,16 @@ async function processTokenToCoin(
   }
 
   const liberdusTssSender = sourceChainState.config.tssSenderAddress
-  const liberdusNonce = tx.timestamp
+  const liberdusReceiptTimestamp = tx.timestamp
 
   if (res.success) {
-    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, signedTxId, liberdusTssSender, liberdusNonce, '')
+    updateTxStatusInLocalDB(txId, TransactionStatus.SUBMITTED, signedTxId, liberdusTssSender, TransactionDB.txReceiptTimestamp(liberdusReceiptTimestamp), '')
     await gossipBridgeIn('liberdus', {
       txId: normalizeTxId(txId),
       sourceChainId,
       receiptId: normalizeTxId(signedTxId),
       liberdusSignedTx: stringify(signedTx as SignedTx),
-      txTimestamp: liberdusNonce,
+      txTimestamp: liberdusReceiptTimestamp,
     }, n, observerUrl)
   }
 
@@ -1906,7 +1906,7 @@ async function processTokenToCoin(
           ? `Refund is successful - original tx ${txId} - refund liberdus tx ${signedTxId} back to Liberdus (associated EVM chain ${sourceChainName})`
           : `Transaction is successful - ethereum tx ${txId} from ${sourceChainName} - liberdus tx ${signedTxId}`,
       )
-      updateTxStatusInLocalDB(txId, finalStatus, signedTxId, liberdusTssSender, liberdusNonce, isRefund ? revertReason ?? '' : '')
+      updateTxStatusInLocalDB(txId, finalStatus, signedTxId, liberdusTssSender, TransactionDB.txReceiptTimestamp(liberdusReceiptTimestamp), isRefund ? revertReason ?? '' : '')
       return finalOutcome
     } else {
       console.log(
@@ -1914,7 +1914,7 @@ async function processTokenToCoin(
       )
       const txData = processingTransactionIds.get(txId)
       if (txData) appendToFailedTxsLogs(txData, receipt.reason)
-      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, signedTxId, liberdusTssSender, liberdusNonce, receipt.reason)
+      updateTxStatusInLocalDB(txId, TransactionStatus.FAILED, signedTxId, liberdusTssSender, TransactionDB.txReceiptTimestamp(liberdusReceiptTimestamp), receipt.reason)
       return 'failed'
     }
   } else {
@@ -1923,7 +1923,7 @@ async function processTokenToCoin(
     )
     const txData = processingTransactionIds.get(txId)
     if (txData) appendToFailedTxsLogs(txData, res.reason ?? `send incompleted from ${sourceChainName}`)
-    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, signedTxId, liberdusTssSender, liberdusNonce, res.reason as string)
+    updateTxStatusInLocalDB(txId, TransactionStatus.INCOMPLETED, signedTxId, liberdusTssSender, TransactionDB.txReceiptTimestamp(liberdusReceiptTimestamp), res.reason as string)
     pendingTxQueueRemovalSet.add(txId)
     return 'incompleted'
   }

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -461,7 +461,9 @@ function buildWhereClause(options?: {
     params.type = options.type;
   }
   if (options?.unprocessed) {
-    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED})`);
+    // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
+    // submitted to the Liberdus network and should not be retried by the party.
+    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED}) AND receiptTimestamp IS NULL`);
   } else if (options?.status !== undefined) {
     clauses.push("status = @status");
     params.status = options.status;

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -431,28 +431,11 @@ export function getTransactionsByNonceRange(
 }
 
 // Returns the highest EVM nonce stored for the given sender on the given chain.
-// Only rows that actually hold an EVM nonce are included:
-//   BRIDGE_IN/BRIDGE_VAULT COMPLETED or FAILED  → processCoinToToken/processVaultBridge ran bridgeIn on EVM
-//   BRIDGE_OUT REVERTED                          → refund bridgeIn was run on EVM
-// Excluded (they store Liberdus timestamps, not EVM nonces):
-//   BRIDGE_OUT COMPLETED or FAILED               → processTokenToCoin ran a Liberdus sendCoin
-//   BRIDGE_IN REVERTED                           → refund ran a Liberdus sendCoin
+// INCOMPLETED is excluded — its nonce is in-flight and not yet confirmed.
 export function getMaxNonceForSender(chainId: number, tssSender: string): number | null {
-  const sql =
-    "SELECT MAX(nonce) AS maxNonce FROM transactions " +
-    "WHERE chainId = @chainId AND tssSender = @tssSender AND nonce IS NOT NULL AND (" +
-      "(status IN (@completed, @failed) AND type IN (@bridgeIn, @bridgeVault)) OR " +
-      "(status = @reverted AND type = @bridgeOut)" +
-    ")"
-  const row = db.prepare(sql).get({
-    chainId, tssSender,
-    completed: TransactionStatus.COMPLETED,
-    failed: TransactionStatus.FAILED,
-    reverted: TransactionStatus.REVERTED,
-    bridgeIn: TransactionType.BRIDGE_IN,
-    bridgeVault: TransactionType.BRIDGE_VAULT,
-    bridgeOut: TransactionType.BRIDGE_OUT,
-  }) as { maxNonce: number | null } | undefined
+  const row = db.prepare(
+    "SELECT MAX(nonce) AS maxNonce FROM transactions WHERE chainId = @chainId AND tssSender = @tssSender AND nonce IS NOT NULL AND status IN (@completed, @failed, @reverted)"
+  ).get({ chainId, tssSender, completed: TransactionStatus.COMPLETED, failed: TransactionStatus.FAILED, reverted: TransactionStatus.REVERTED }) as { maxNonce: number | null } | undefined
   return row?.maxNonce ?? null
 }
 

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -343,6 +343,7 @@ export function getTotalTransactions(options?: {
   type?: TransactionType;
   status?: TransactionStatus;
   unprocessed?: boolean;
+  partyRetryable?: boolean;
 }): number {
   const { sql, params } = buildWhereClause(options);
   const query = `SELECT COUNT(*) as count FROM transactions${sql ? ` WHERE ${sql}` : ""}`;
@@ -358,6 +359,7 @@ export function getTransactionsByPage(
     type?: TransactionType;
     status?: TransactionStatus;
     unprocessed?: boolean;
+    partyRetryable?: boolean;
   }
 ): Transaction[] {
   const { sql, params } = buildWhereClause(options);
@@ -448,6 +450,7 @@ function buildWhereClause(options?: {
   type?: TransactionType;
   status?: TransactionStatus;
   unprocessed?: boolean;
+  partyRetryable?: boolean;
 }): { sql: string; params: Record<string, any> } {
   const clauses: string[] = [];
   const params: Record<string, any> = {};
@@ -461,9 +464,13 @@ function buildWhereClause(options?: {
     params.type = options.type;
   }
   if (options?.unprocessed) {
-    // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
-    // submitted to the Liberdus network and should not be retried by the party.
-    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED}) AND receiptTimestamp IS NULL`);
+    // Not yet in a terminal state (COMPLETED/FAILED/REVERTED).
+    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED})`);
+    if (options.partyRetryable) {
+      // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
+      // submitted to the Liberdus network and should not be retried by the party.
+      clauses.push("receiptTimestamp IS NULL");
+    }
   } else if (options?.status !== undefined) {
     clauses.push("status = @status");
     params.status = options.status;

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -290,7 +290,7 @@ export function updateTransactionStatus(
       return "no_downgrade";
     }
 
-    // Use the passed-in nonce/timestamp if provided, otherwise fall back to the row's existing values
+    // Use the passed-in nonce/receiptTimestamp if provided, otherwise fall back to the row's existing values
     const effectiveTssSender = tssSender ?? current.tssSender;
     const effectiveNonce =
       receiptRef?.type === 'nonce' ? receiptRef.value : current.nonce;

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -10,17 +10,29 @@ export interface Transaction {
   sender: string;
   value: string;
   type: TransactionType;
-  txTimestamp: number;
+  txTimestamp: number;                // Source bridge tx timestamp (ms)
   chainId: number;
   status: TransactionStatus;
   receiptId: string;
   tssSender?: string | null;          // TSS sender address used for this tx
-  nonce?: number | null;              // EVM sender nonce OR Liberdus tx timestamp
+  nonce?: number | null;              // EVM tssSender account nonce from the on-chain receipt; null for Liberdus txs
+  receiptTimestamp?: number | null;   // Liberdus tssSender receipt timestamp (ms); null for EVM txs
   reason?: string | null;             // Reason for failure
   executionHistory?: string | null;   // JSON: tracks failed/incompleted tx attempts
   createdAt?: number;
   updatedAt?: number;
 }
+
+// Chain-native receipt reference:
+//   - 'nonce'            → EVM tssSender account nonce
+//   - 'receiptTimestamp' → Liberdus receipt timestamp (ms)
+export type TxReceiptRef =
+  | { type: 'nonce'; value: number }
+  | { type: 'receiptTimestamp'; value: number }
+  | null;
+
+export const txNonce = (value: number): TxReceiptRef => ({ type: 'nonce', value });
+export const txReceiptTimestamp = (value: number): TxReceiptRef => ({ type: 'receiptTimestamp', value });
 
 export interface ExecutionHistoryEntry {
   status: TransactionStatus;
@@ -101,6 +113,7 @@ export function initializeTransactionsDatabase(dbPath: string): void {
       status           INTEGER NOT NULL,
       tssSender        TEXT,
       nonce            INTEGER,
+      receiptTimestamp BIGINT,
       reason           TEXT,
       executionHistory TEXT DEFAULT '{}',
       createdAt        INTEGER DEFAULT (strftime('%s','now')),
@@ -127,18 +140,30 @@ export function initializeTransactionsDatabase(dbPath: string): void {
       ON transactions(chainId, tssSender, status, nonce);
   `);
 
+  // Migration: add receiptTimestamp column to existing databases (must run before the index below)
+  try {
+    db.exec("ALTER TABLE transactions ADD COLUMN receiptTimestamp BIGINT");
+  } catch {
+    // Column already exists — expected on all but first run after this deploy
+  }
+
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_transactions_receiptTimestamp
+      ON transactions(receiptTimestamp);
+  `);
+
   stmtGetById = db.prepare("SELECT * FROM transactions WHERE txId = ?");
   stmtGetByReceiptId = db.prepare("SELECT * FROM transactions WHERE receiptId = ? ORDER BY updatedAt DESC LIMIT 1");
 
   stmtInsert = db.prepare(`
     INSERT OR IGNORE INTO transactions
-      (txId, sender, value, type, txTimestamp, receiptId, chainId, status, tssSender, nonce, reason, executionHistory)
+      (txId, sender, value, type, txTimestamp, receiptId, chainId, status, tssSender, nonce, receiptTimestamp, reason, executionHistory)
     VALUES
-      (@txId, @sender, @value, @type, @txTimestamp, @receiptId, @chainId, @status, @tssSender, @nonce, @reason, @executionHistory)
+      (@txId, @sender, @value, @type, @txTimestamp, @receiptId, @chainId, @status, @tssSender, @nonce, @receiptTimestamp, @reason, @executionHistory)
   `);
 
   stmtUpdateStatus = db.prepare(
-    "UPDATE transactions SET status = @status, receiptId = @receiptId, tssSender = @tssSender, nonce = @nonce, reason = @reason, executionHistory = @executionHistory WHERE txId = @txId"
+    "UPDATE transactions SET status = @status, receiptId = @receiptId, tssSender = @tssSender, nonce = @nonce, receiptTimestamp = @receiptTimestamp, reason = @reason, executionHistory = @executionHistory WHERE txId = @txId"
   );
 
   console.log("[db] initialized");
@@ -160,6 +185,7 @@ export function saveTransaction(transaction: Transaction): void {
     status: transaction.status,
     tssSender: transaction.tssSender ?? null,
     nonce: transaction.nonce ?? null,
+    receiptTimestamp: transaction.receiptTimestamp ?? null,
     reason: transaction.reason ?? null,
     executionHistory: transaction.executionHistory ?? "{}",
   });
@@ -222,7 +248,7 @@ export function updateTransactionStatus(
   status: TransactionStatus,
   receiptId: string,
   tssSender: string,
-  nonce: number,
+  receiptRef: TxReceiptRef,
   reason: string | null,
 ): UpdateStatusResult {
   const run = db.transaction((): UpdateStatusResult => {
@@ -264,9 +290,12 @@ export function updateTransactionStatus(
       return "no_downgrade";
     }
 
-    // Use the passed-in nonce if provided, otherwise fall back to the row's existing nonce
+    // Use the passed-in nonce/timestamp if provided, otherwise fall back to the row's existing values
     const effectiveTssSender = tssSender ?? current.tssSender;
-    const effectiveNonce = nonce ?? current.nonce;
+    const effectiveNonce =
+      receiptRef?.type === 'nonce' ? receiptRef.value : current.nonce;
+    const effectiveReceiptTimestamp =
+      receiptRef?.type === 'receiptTimestamp' ? receiptRef.value : current.receiptTimestamp;
 
     // Auto-append to executionHistory when transitioning to INCOMPLETED or FAILED
     // and a nonce is known (meaning a signing attempt was made).
@@ -289,6 +318,7 @@ export function updateTransactionStatus(
       receiptId,
       tssSender: effectiveTssSender ?? null,
       nonce: effectiveNonce ?? null,
+      receiptTimestamp: effectiveReceiptTimestamp ?? null,
       reason,
       executionHistory: updatedHistory,
       txId,


### PR DESCRIPTION
feat: add receiptTimestamp field to transactions DB, separate from nonce
- Add `receiptTimestamp BIGINT` column to the transactions schema with a
  SQLite migration (ALTER TABLE) for existing databases; index added after
  migration to avoid "no such column" on old schemas
- Introduce `TxReceiptRef` discriminated union type (`'nonce' | 'receiptTimestamp'`)
  with `txNonce()` and `txReceiptTimestamp()` factory helpers to make
  chain-specific receipt references explicit and mutually exclusive
- `nonce` is now EVM-only (tssSender account nonce); `receiptTimestamp`
  carries the Liberdus receipt timestamp (ms) — no longer conflated in one field
- Update `updateTransactionStatus` signature to accept `TxReceiptRef` instead
  of a raw nonce number; `updateTxStatusInLocalDB` in tss-party follows the
  same interface
- Fix receipt verification in liberdus monitor to compare `tx.receiptTimestamp`
  instead of `tx.nonce`
- Clarify `txTimestamp` as the source bridge tx timestamp in the Transaction
  interface comment
  
refactor: simplify getMaxNonceForSender now that nonce is EVM-only
- Remove stale tx-type filter (was needed when nonce held Liberdus timestamps)
- Exclude INCOMPLETED status — in-flight nonces are not yet confirmed
- Final filter: nonce IS NOT NULL AND status IN (COMPLETED, FAILED, REVERTED)