### PR TITLE
Refactor/liberdus delivery reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ Right now there are three TSS execution routes:
 2. TSS parties poll the paired observer every 10s for unprocessed transactions
 3. Each party independently queues the pending transaction from its local observer
 4. Parties sign through the native BNB TSS flow
-5. Winning party broadcasts the signed tx to Liberdus and updates local status
+5. Winning party broadcasts the signed tx to Liberdus and sets status to SUBMITTED with `receiptTimestamp`
 6. Winning party gossips Liberdus submission (`txId`, `receiptId`, `sourceChainId`) to peer observers via `/bridgein/liberdus/submitted` so peers can mark the source tx as SUBMITTED early (`txId` is source `bridgeOut` tx id, `receiptId` is destination `bridgeIn` tx id)
+7. Observer detects the delivery receipt from the Liberdus collector API and reconciles the final status (COMPLETED/FAILED/REVERTED); parties do not retry once `receiptTimestamp` is set
 
 **Liberdus -> EVM BridgeIn (Coin-to-Token):**
 1. Observer polls the Liberdus collector API for bridge transfers and saves them as PENDING

--- a/observer/monitor/liberdus.ts
+++ b/observer/monitor/liberdus.ts
@@ -1,14 +1,12 @@
 import { ethers } from "ethers";
 import axios from "axios";
 import * as TransactionDB from "../../shared/storage/transactiondb";
-import { chainConfigsRaw, getChainConfigById, paramsConfigRaw } from "../../shared/config";
+import { ChainConfig, chainConfigsRaw, getChainConfigById, paramsConfigRaw } from "../../shared/config";
 import { getCachedPeerObserverUrls } from "../../shared/utils/observerPeers";
 import { toEthereumAddress, toShardusAddress } from "../../shared/utils/transformAddress";
 import { normalizeTxId } from "../../shared/utils/transformTxId";
 import { observerChainRpc } from "../chainRpc";
 import { monitorState, saveMonitorState } from "./state";
-
-const PEER_TX_LOOKUP_TIMEOUT_MS = 4_000;
 
 const BRIDGE_OUT_EVENT_ABI =
   "event BridgedOut(address indexed from, uint256 amount, address indexed targetAddress, uint256 indexed chainId, uint256 timestamp)";
@@ -23,17 +21,21 @@ type ParsedLiberdusBridgeTxBase = {
 
 type ParsedLiberdusBridgeTx =
   | (ParsedLiberdusBridgeTxBase & {
-      txType: TransactionDB.TransactionType.BRIDGE_IN;
-      txId: string;
-    })
+    txType: TransactionDB.TransactionType.BRIDGE_IN;
+    txId: string;
+  })
   | (ParsedLiberdusBridgeTxBase & {
-      txType: TransactionDB.TransactionType.BRIDGE_OUT;
-      receiptId: string;
-    });
+    txType: TransactionDB.TransactionType.BRIDGE_OUT;
+    receiptId: string;
+  });
 
 type VerificationResult = { ok: boolean; reason?: string };
+type ObservationVerification = VerificationResult & {
+  finalStatus?: TransactionDB.TransactionStatus;
+};
 
-function isTerminalStatus(status: TransactionDB.TransactionStatus): boolean {
+
+function isFinalizedStatus(status: TransactionDB.TransactionStatus): boolean {
   return (
     status === TransactionDB.TransactionStatus.COMPLETED ||
     status === TransactionDB.TransactionStatus.FAILED ||
@@ -56,7 +58,8 @@ export async function monitorLiberdusTransactions(): Promise<void> {
       chainConfigsRaw.supportedChains
     )) {
       const chainId = parseInt(chainIdStr);
-      const { bridgeAddress } = chainConfig as any;
+      const { tssSenderAddress } = chainConfig as ChainConfig;
+      const bridgeAddress = toShardusAddress(tssSenderAddress);
 
       let page = 1;
       while (true) {
@@ -118,13 +121,81 @@ export async function monitorLiberdusTransactions(): Promise<void> {
             );
           } else {
             const { receiptId, status, txTimestamp } = parsed;
-            const reconciled = await reconcileObservedLiberdusBridgeOut(receiptId, status, txTimestamp);
-            if (!reconciled) {
-              console.log(
-                `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${
-                  TransactionDB.getStatusLabel(status)
-                } (sourceChain txId not found locally or from verified peers)`
+
+            const existingTx = TransactionDB.getTransactionByReceiptId(receiptId);
+            if (existingTx) {
+              const expectedStatus = getFinalizedTxStatus(existingTx.type, status);
+              const isFinalized = isFinalizedStatus(existingTx.status);
+              const tssSenderMismatch =
+                existingTx.tssSender &&
+                toEthereumAddress(existingTx.tssSender ?? "") !==
+                toEthereumAddress(tssSenderAddress);
+              const statusMismatch =
+                existingTx.status && existingTx.status !== expectedStatus;
+              const receiptIdMismatch =
+                existingTx.receiptId && existingTx.receiptId !== receiptId;
+              const receiptTimestampMismatch =
+                existingTx.receiptTimestamp &&
+                existingTx.receiptTimestamp !== txTimestamp;
+              if (isFinalized) {
+                // Already settled — verify the observed delivery matches what we recorded.
+                if (statusMismatch) {
+                  console.warn(
+                    `[observer/liberdus] Status mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${TransactionDB.getStatusLabel(existingTx.status)} expected=${TransactionDB.getStatusLabel(expectedStatus)}`,
+                  );
+                }
+                if (receiptIdMismatch) {
+                  console.warn(
+                    `[observer/liberdus] ReceiptId mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${existingTx.receiptId} expected=${receiptId}`,
+                  );
+                }
+                if (receiptTimestampMismatch) {
+                  console.warn(
+                    `[observer/liberdus] ReceiptTimestamp mismatch for settled ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId}: stored=${existingTx.receiptTimestamp} expected=${txTimestamp}`,
+                  );
+                }
+                if (!tssSenderMismatch && !statusMismatch && !receiptIdMismatch && !receiptTimestampMismatch) {
+                  console.log(
+                    `[observer/liberdus] Already saved ${TransactionDB.TransactionType[existingTx.type]} txId=${existingTx.txId} status=${TransactionDB.getStatusLabel(existingTx.status)}`,
+                  );
+                  continue;
+                }
+              }
+              const result = TransactionDB.updateTransactionStatus(
+                existingTx.txId,
+                expectedStatus,
+                receiptId,
+                toEthereumAddress(tssSenderAddress),
+                { type: "receiptTimestamp", value: txTimestamp },
+                null,
               );
+              if (result === "ok") {
+                console.log(
+                  `[observer/liberdus] Updated status for existing txId=${existingTx.txId} to ${TransactionDB.getStatusLabel(expectedStatus)}`,
+                );
+              } else {
+                console.warn(
+                  `[observer/liberdus] Failed to update status for existing txId=${existingTx.txId} to ${TransactionDB.getStatusLabel(expectedStatus)}: ${result}`,
+                );
+              }
+            } else {
+              console.warn(
+                `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${TransactionDB.getStatusLabel(
+                  status,
+                )} (sourceChain txId not found locally)`,
+              )
+              const reconciled = await reconcileObservedLiberdusBridgeOut(
+                receiptId,
+                status,
+                txTimestamp,
+              );
+              if (!reconciled) {
+                console.log(
+                  `[observer/liberdus] Liberdus bridge delivery observed receiptId=${receiptId} status=${TransactionDB.getStatusLabel(
+                    status,
+                  )} (sourceChain txId not found locally or from verified peers)`,
+                );
+              }
             }
           }
         }
@@ -193,14 +264,14 @@ async function fetchPeerTransactionByReceiptId(receiptId: string): Promise<Trans
     try {
       const response = await axios.get(`${baseUrl}/transaction`, {
         params: { receiptId },
-        timeout: PEER_TX_LOOKUP_TIMEOUT_MS,
+        timeout: 3_000,
       });
       const txs = response.data?.Ok?.transactions;
       if (Array.isArray(txs) && txs.length > 0) {
         const tx = txs[0] as TransactionDB.Transaction;
-        if (!isTerminalStatus(tx.status)) {
+        if (!isFinalizedStatus(tx.status)) {
           console.warn(
-            `[observer/liberdus] Peer tx found for receiptId=${receiptId} but status=${TransactionDB.getStatusLabel(tx.status)} is not terminal`,
+            `[observer/liberdus] Peer tx found for receiptId=${receiptId} but status=${TransactionDB.getStatusLabel(tx.status)} is not finalized`,
           );
           continue;
         }
@@ -213,7 +284,9 @@ async function fetchPeerTransactionByReceiptId(receiptId: string): Promise<Trans
   return null;
 }
 
-async function verifyEvmBridgeOutSourceTx(tx: TransactionDB.Transaction): Promise<VerificationResult> {
+async function verifyEvmBridgeOutSourceTx(
+  tx: TransactionDB.Transaction,
+): Promise<VerificationResult> {
   const sourceChain = getChainConfigById(chainConfigsRaw, tx.chainId);
   if (!sourceChain?.contractAddress) {
     return { ok: false, reason: "missing_source_chain_contract" };
@@ -268,6 +341,25 @@ async function verifyEvmBridgeOutSourceTx(tx: TransactionDB.Transaction): Promis
   }
 }
 
+async function retryFetch<T>(
+  fn: () => Promise<T>,
+  maxRetries = 3,
+  delayMs = 500,
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) {
+        await new Promise((r) => setTimeout(r, delayMs * (attempt + 1)));
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function verifyLiberdusTx(
   txId: string,
   expected: { success: boolean; from: string; amount: string },
@@ -276,9 +368,9 @@ async function verifyLiberdusTx(
     process.env.PROXY_SERVER_HOST || chainConfigsRaw.proxyServerHost || "http://127.0.0.1:3030";
 
   try {
-    const response = await axios.get(`${proxyServerHost}/transaction/${txId}`, {
-      timeout: 10_000,
-    });
+    const response = await retryFetch(() =>
+      axios.get(`${proxyServerHost}/transaction/${txId}`, { timeout: 5_000 }),
+    );
     const tx = response.data?.transaction;
     if (!tx) return { ok: false, reason: "missing_liberdus_tx" };
     const success = tx.success;
@@ -323,74 +415,30 @@ async function verifyLiberdusTx(
   }
 }
 
-function terminalStatusFromObservation(
-  tx: TransactionDB.Transaction,
+function getFinalizedTxStatus(
+  txType: TransactionDB.TransactionType,
   observedStatus: TransactionDB.TransactionStatus,
 ): TransactionDB.TransactionStatus {
-  if (isTerminalStatus(tx.status)) {
-    return tx.status;
-  }
-  if (
-    tx.type === TransactionDB.TransactionType.BRIDGE_IN &&
+  // BRIDGE_IN + observed COMPLETED means a successful refund, stored as REVERTED.
+  return txType === TransactionDB.TransactionType.BRIDGE_IN &&
     observedStatus === TransactionDB.TransactionStatus.COMPLETED
-  ) {
-    return TransactionDB.TransactionStatus.REVERTED;
-  }
-  return observedStatus;
+    ? TransactionDB.TransactionStatus.REVERTED
+    : observedStatus;
 }
 
-function isSupportedObservedTx(tx: TransactionDB.Transaction): boolean {
+function isReconcilableTxType(tx: TransactionDB.Transaction): boolean {
   return (
     tx.type === TransactionDB.TransactionType.BRIDGE_OUT ||
     tx.type === TransactionDB.TransactionType.BRIDGE_IN
   );
 }
 
-async function verifyObservedLiberdusReceipt(
+async function verifySourceBridgeTx(
   tx: TransactionDB.Transaction,
-  observedReceiptId: string,
-  finalStatus: TransactionDB.TransactionStatus,
-): Promise<VerificationResult> {
-  const liberdusBridgeAddress = getChainConfigById(chainConfigsRaw, tx.chainId)?.bridgeAddress;
-  if (!liberdusBridgeAddress) {
-    return { ok: false, reason: "missing_liberdus_bridge_address" };
-  }
-
-  const receiptVerification = await verifyLiberdusTx(observedReceiptId, {
-    success: finalStatus !== TransactionDB.TransactionStatus.FAILED,
-    from: liberdusBridgeAddress,
-    amount: tx.value,
-  });
-  if (!receiptVerification.ok) return receiptVerification;
-
-  if (tx.type === TransactionDB.TransactionType.BRIDGE_OUT) {
-    return verifyEvmBridgeOutSourceTx(tx);
-  }
-
-  if (
-    tx.type === TransactionDB.TransactionType.BRIDGE_IN &&
-    (
-      finalStatus === TransactionDB.TransactionStatus.REVERTED ||
-      finalStatus === TransactionDB.TransactionStatus.FAILED
-    )
-  ) {
-    return verifyLiberdusTx(tx.txId, {
-      success: true,
-      from: tx.sender,
-      amount: tx.value,
-    });
-  }
-
-  return { ok: false, reason: "unsupported_tx_type_or_status_for_liberdus_receipt" };
-}
-
-async function verifyObservedTx(
-  tx: TransactionDB.Transaction,
-  receiptId: string,
   observedStatus: TransactionDB.TransactionStatus,
   receiptTxTimestamp: number,
-): Promise<{ ok: boolean; finalStatus?: TransactionDB.TransactionStatus; reason?: string }> {
-  if (!isSupportedObservedTx(tx)) {
+): Promise<ObservationVerification> {
+  if (!isReconcilableTxType(tx)) {
     return { ok: false, reason: `unsupported_tx_type_${tx.type}` };
   }
   const chainConfig = getChainConfigById(chainConfigsRaw, tx.chainId);
@@ -407,66 +455,33 @@ async function verifyObservedTx(
     return { ok: false, reason: "receiptTimestamp_mismatch" };
   }
 
-  const finalStatus = terminalStatusFromObservation(tx, observedStatus);
-  const verification = await verifyObservedLiberdusReceipt(
-    tx,
-    receiptId,
-    finalStatus,
-  );
-  return verification.ok
-    ? { ok: true, finalStatus }
-    : { ok: false, reason: verification.reason };
-}
+  const expectedStatus = getFinalizedTxStatus(tx.type, observedStatus);
+  if (tx.status !== expectedStatus) {
+    return { ok: false, reason: `observed_status_mismatch(expected=${expectedStatus}, found=${tx.status})` };
+  }
+  const finalStatus = expectedStatus;
 
-function updateObservedTransactionStatus(
-  tx: TransactionDB.Transaction,
-  receiptId: string,
-  status: TransactionDB.TransactionStatus,
-  receiptTxTimestamp: number,
-): boolean {
-  const chainConfig = getChainConfigById(chainConfigsRaw, tx.chainId);
-  if (!chainConfig?.tssSenderAddress) {
-    console.warn(`[observer/liberdus] Cannot update ${TransactionDB.TransactionType[tx.type]} txId=${tx.txId}: missing chain tssSenderAddress`);
-    return false;
+  if (tx.type === TransactionDB.TransactionType.BRIDGE_OUT) {
+    // Verify the original EVM source tx that triggered this bridge-out delivery.
+    const evmVerification = await verifyEvmBridgeOutSourceTx(tx);
+    return evmVerification.ok ? { ok: true, finalStatus } : evmVerification;
   }
 
-  const result = TransactionDB.updateTransactionStatus(
-    tx.txId,
-    status,
-    receiptId,
-    toEthereumAddress(chainConfig.tssSenderAddress),
-    { type: "receiptTimestamp", value: receiptTxTimestamp },
-    tx.reason ?? null,
-  );
-  console.log(
-    `[observer/liberdus] Updated ${TransactionDB.TransactionType[tx.type]} txId=${tx.txId} receiptId=${receiptId} -> ${TransactionDB.getStatusLabel(status)} result=${result}`,
-  );
-  return result !== "not_found";
+  // BRIDGE_IN: delivery is a refund — verify the original Liberdus source tx (user → bridge).
+  const sourceVerification = await verifyLiberdusTx(tx.txId, {
+    success: true,
+    from: tx.sender,
+    amount: tx.value,
+  });
+  return sourceVerification.ok ? { ok: true, finalStatus } : sourceVerification;
 }
 
+
 async function reconcileObservedLiberdusBridgeOut(
-  receiptId: string,
+  normalizedReceiptId: string,
   status: TransactionDB.TransactionStatus,
   receiptTxTimestamp: number,
 ): Promise<boolean> {
-  const normalizedReceiptId = normalizeTxId(receiptId);
-
-  const localTx = TransactionDB.getTransactionByReceiptId(normalizedReceiptId);
-  if (localTx) {
-    const verified = await verifyObservedTx(localTx, normalizedReceiptId, status, receiptTxTimestamp);
-    if (!verified.ok || verified.finalStatus == null) {
-      console.warn(
-        `[observer/liberdus] Local tx found for receiptId=${normalizedReceiptId} but verification failed (${verified.reason})`,
-      );
-      if (isTerminalStatus(localTx.status)) return false;
-      console.warn(
-        `[observer/liberdus] Local tx for receiptId=${normalizedReceiptId} is non-terminal; trying verified peer backfill`,
-      );
-    } else {
-      return updateObservedTransactionStatus(localTx, normalizedReceiptId, verified.finalStatus, receiptTxTimestamp);
-    }
-  }
-
   const peerTx = await fetchPeerTransactionByReceiptId(normalizedReceiptId);
   if (!peerTx) return false;
 
@@ -487,7 +502,11 @@ async function reconcileObservedLiberdusBridgeOut(
     return false;
   }
 
-  const verified = await verifyObservedTx(peerTx, normalizedReceiptId, status, receiptTxTimestamp);
+  const verified = await verifySourceBridgeTx(
+    peerTx,
+    status,
+    receiptTxTimestamp,
+  );
   if (!verified.ok || verified.finalStatus == null) {
     console.warn(
       `[observer/liberdus] Peer tx found for receiptId=${normalizedReceiptId} but verification failed (${verified.reason})`,
@@ -495,13 +514,36 @@ async function reconcileObservedLiberdusBridgeOut(
     return false;
   }
 
-  const existingByTxId = TransactionDB.getTransactionById(normalizeTxId(peerTx.txId));
+  const normalizedTxId = normalizeTxId(peerTx.txId);
+  const existingByTxId = TransactionDB.getTransactionById(normalizedTxId);
   if (existingByTxId) {
-    return updateObservedTransactionStatus(existingByTxId, normalizedReceiptId, verified.finalStatus, receiptTxTimestamp);
+    const chainConfig = getChainConfigById(chainConfigsRaw, existingByTxId.chainId);
+    if (!chainConfig?.tssSenderAddress) {
+      console.warn(`[observer/liberdus] Cannot update ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId}: missing chain tssSenderAddress`);
+      return false;
+    }
+    const result = TransactionDB.updateTransactionStatus(
+      existingByTxId.txId,
+      verified.finalStatus,
+      normalizedReceiptId,
+      toEthereumAddress(chainConfig.tssSenderAddress),
+      { type: "receiptTimestamp", value: receiptTxTimestamp },
+      existingByTxId.reason ?? null,
+    );
+    if (result === "ok") {
+      console.log(
+        `[observer/liberdus] Updated ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId} receiptId=${normalizedReceiptId} -> ${TransactionDB.getStatusLabel(verified.finalStatus)}`,
+      );
+    } else {
+      console.warn(
+        `[observer/liberdus] Failed to update ${TransactionDB.TransactionType[existingByTxId.type]} txId=${existingByTxId.txId} -> ${TransactionDB.getStatusLabel(verified.finalStatus)}: ${result}`,
+      );
+    }
+    return result !== "not_found";
   }
 
   const reconciledTx: TransactionDB.Transaction = {
-    txId: normalizeTxId(peerTx.txId),
+    txId: normalizedTxId,
     sender: peerTx.sender,
     value: peerTx.value,
     type: peerTx.type,

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -594,7 +594,7 @@ function updateTxStatusInLocalDB(
 async function pollPendingTransactionsFromLocalDB(): Promise<void> {
   if (verboseLogs) console.log('Polling pending transactions from local DB...', new Date().toISOString())
   try {
-    const dbTxs = TransactionDB.getTransactionsByPage(10, 0, { unprocessed: true })
+    const dbTxs = TransactionDB.getTransactionsByPage(10, 0, { unprocessed: true, partyRetryable: true })
     const transactions: Transaction[] = dbTxs
       .slice()
       .sort((a, b) => a.txTimestamp - b.txTimestamp)
@@ -678,17 +678,7 @@ async function pollPendingTransactionsFromLocalDB(): Promise<void> {
 }
 
 
-function checkTxStatusFromLocalDB(txId: string): TransactionStatus | null {
-  try {
-    const normalizedTxId = normalizeTxId(txId)
-    const tx = TransactionDB.getTransactionById(normalizedTxId)
-    if (!tx) return null
-    return tx.status
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    throw new Error(`[checkTxStatus] DB read failed for ${txId}: ${errorMessage}`)
-  }
-}
+
 
 // ---------------------------------------------------------------------------
 // Nonce manager — tracks the expected next EVM nonce per chain per sender.
@@ -766,7 +756,7 @@ const signedTxCache: Map<string, { signedTx: string; txHash: string; nonce: numb
 // ---------------------------------------------------------------------------
 function reconcileTxStatusWithLocalDB(
   txId: string,
-  context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit',
+  context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit' | 'timeout',
 // 'submitted' is Liberdus-only: EVM txs in SUBMITTED/INCOMPLETED are retried by the party.
 ): null | 'submitted' | 'completed' | 'failed' | 'reverted' {
   if (DEBUG_SKIP_TX_STATUS_CHECK) return null
@@ -2478,8 +2468,12 @@ async function main(): Promise<void> {
           console.warn('Transaction processing timed out', validTx.txId)
         }
 
-        const finalStatus = checkTxStatusFromLocalDB(validTx.txId)
-        if (finalStatus === TransactionStatus.COMPLETED) {
+        const dbStatus = reconcileTxStatusWithLocalDB(validTx.txId, 'timeout')
+        if (dbStatus === 'submitted') {
+          txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+          pendingTxQueueRemovalSet.add(txId)
+          console.log(`[${timeoutReason}] ${validTx.txId} already submitted to Liberdus`)
+        } else if (dbStatus === 'completed') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'completed' })
           pendingTxQueueRemovalSet.add(txId)
           // Another party submitted this tx — nonce was consumed, advance local tracker
@@ -2493,12 +2487,16 @@ async function main(): Promise<void> {
             incrementLocalNonce(nonceCacheChainId, nonceTssSender)
           }
           console.log(`[${timeoutReason}] ${validTx.txId} already COMPLETED in local DB`)
-        } else if (finalStatus === TransactionStatus.REVERTED) {
+        } else if (dbStatus === 'reverted') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'reverted' })
           pendingTxQueueRemovalSet.add(txId)
           console.log(`[${timeoutReason}] ${validTx.txId} already REVERTED in local DB`)
-        } else {
+        } else if (dbStatus === 'failed') {
           txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'failed' })
+          pendingTxQueueRemovalSet.add(txId)
+          console.warn(`[${timeoutReason}] ${validTx.txId} already FAILED in local DB`)
+        } else {
+          txQueueMap.set(validTx.txId, { txTimestamp: validTx.txTimestamp!, status: 'incompleted' })
           appendToFailedTxsLogs(validTx, timeoutReason)
           console.warn(`[${timeoutReason}] ${validTx.txId} not completed in local DB`)
         }

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -73,7 +73,7 @@ interface TransactionQueueItem {
 
 interface TxQueueEntry {
   txTimestamp: number // milliseconds, from source-chain event/block time
-  status: 'pending' | 'processing' | 'completed' | 'incompleted' | 'failed' | 'reverted'
+  status: 'pending' | 'processing' | 'submitted' | 'completed' | 'incompleted' | 'failed' | 'reverted'
 }
 
 interface PartyInfo {
@@ -105,7 +105,7 @@ interface SignedTx {
   }
 }
 
-type ProcessOutcome = 'completed' | 'incompleted' | 'failed' | 'reverted' | 'skipped_db_completed' | 'skipped_db_failed' | 'skipped_db_reverted'
+type ProcessOutcome = 'completed' | 'incompleted' | 'failed' | 'reverted' | 'skipped_db_submitted' | 'skipped_db_completed' | 'skipped_db_failed' | 'skipped_db_reverted'
 
 // Receipt is polled only while remaining cooldown time exceeds (bridgeInCooldown - this value).
 // e.g. for a 60s cooldown: poll while remainingMs > 45s, skip receipt checks once < 45s remains —
@@ -767,12 +767,27 @@ const signedTxCache: Map<string, { signedTx: string; txHash: string; nonce: numb
 function reconcileTxStatusWithLocalDB(
   txId: string,
   context: 'pre-process' | 'pre-sign' | 'post-sign' | 'pre-submit',
-): null | 'completed' | 'failed' | 'reverted' {
+// 'submitted' is Liberdus-only: EVM txs in SUBMITTED/INCOMPLETED are retried by the party.
+): null | 'submitted' | 'completed' | 'failed' | 'reverted' {
   if (DEBUG_SKIP_TX_STATUS_CHECK) return null
   try {
-    const status = checkTxStatusFromLocalDB(txId)
+    const normalizedTxId = normalizeTxId(txId)
+    const tx = TransactionDB.getTransactionById(normalizedTxId)
+    if (!tx) return null
+
+    const { status } = tx
+
+    // Liberdus txs (receiptTimestamp set) in SUBMITTED/INCOMPLETED have been delivered
+    // to the Liberdus network — the party should not retry them.
     if (
-      status == null ||
+      (status === TransactionStatus.SUBMITTED || status === TransactionStatus.INCOMPLETED) &&
+      tx.receiptTimestamp != null
+    ) {
+      console.log(`⏩ ${txId} already submitted to Liberdus (${context}), skipping`)
+      return 'submitted'
+    }
+
+    if (
       status === TransactionStatus.PENDING ||
       status === TransactionStatus.SUBMITTED ||
       status === TransactionStatus.INCOMPLETED
@@ -794,8 +809,9 @@ function reconcileTxStatusWithLocalDB(
 
 // Maps a reconcile skip status to the corresponding ProcessOutcome.
 function dbStatusToSkipOutcome(
-  status: 'completed' | 'failed' | 'reverted',
+  status: 'submitted' | 'completed' | 'failed' | 'reverted',
 ): ProcessOutcome {
+  if (status === 'submitted') return 'skipped_db_submitted'
   if (status === 'completed') return 'skipped_db_completed'
   if (status === 'reverted') return 'skipped_db_reverted'
   return 'skipped_db_failed'
@@ -2343,7 +2359,10 @@ async function main(): Promise<void> {
       const tssSender = validTx.type === 'vaultBridge'
         ? chainConfigs.secondaryChainConfig!.tssSenderAddress!
         : getChainConfigById(chainConfigs, validTx.chainId)!.tssSenderAddress!
-      if (preProcess === 'completed') {
+      if (preProcess === 'submitted') {
+        txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+        appendToFailedTxsLogs(validTx, 'already submitted to Liberdus at pre-process')
+      } else if (preProcess === 'completed') {
         syncLocalNonceFromDB(validTx.type, validTx.chainId, tssSender)
         txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'completed' })
       } else if (preProcess === 'failed') {
@@ -2434,6 +2453,11 @@ async function main(): Promise<void> {
         console.log(`Transaction ${validTx.txId} was already reverted in local DB during reconcile, skipping`)
         txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'reverted' })
         pendingTxQueueRemovalSet.add(txId)
+      } else if (outcome === 'skipped_db_submitted') {
+        console.log(`Transaction ${validTx.txId} was already submitted to Liberdus during reconcile, skipping`)
+        txQueueMap.set(txId, { txTimestamp: validTx.txTimestamp!, status: 'submitted' })
+        pendingTxQueueRemovalSet.add(txId)
+        appendToFailedTxsLogs(validTx, 'already submitted to Liberdus during reconcile')
       }
 
       // Check memory usage after successful transaction

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -461,7 +461,9 @@ function buildWhereClause(options?: {
     params.type = options.type;
   }
   if (options?.unprocessed) {
-    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED})`);
+    // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
+    // submitted to the Liberdus network and should not be retried by the party.
+    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED}) AND receiptTimestamp IS NULL`);
   } else if (options?.status !== undefined) {
     clauses.push("status = @status");
     params.status = options.status;

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -343,6 +343,7 @@ export function getTotalTransactions(options?: {
   type?: TransactionType;
   status?: TransactionStatus;
   unprocessed?: boolean;
+  partyRetryable?: boolean;
 }): number {
   const { sql, params } = buildWhereClause(options);
   const query = `SELECT COUNT(*) as count FROM transactions${sql ? ` WHERE ${sql}` : ""}`;
@@ -358,6 +359,7 @@ export function getTransactionsByPage(
     type?: TransactionType;
     status?: TransactionStatus;
     unprocessed?: boolean;
+    partyRetryable?: boolean;
   }
 ): Transaction[] {
   const { sql, params } = buildWhereClause(options);
@@ -448,6 +450,7 @@ function buildWhereClause(options?: {
   type?: TransactionType;
   status?: TransactionStatus;
   unprocessed?: boolean;
+  partyRetryable?: boolean;
 }): { sql: string; params: Record<string, any> } {
   const clauses: string[] = [];
   const params: Record<string, any> = {};
@@ -461,9 +464,13 @@ function buildWhereClause(options?: {
     params.type = options.type;
   }
   if (options?.unprocessed) {
-    // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
-    // submitted to the Liberdus network and should not be retried by the party.
-    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED}) AND receiptTimestamp IS NULL`);
+    // Not yet in a terminal state (COMPLETED/FAILED/REVERTED).
+    clauses.push(`status IN (${TransactionStatus.PENDING}, ${TransactionStatus.SUBMITTED}, ${TransactionStatus.INCOMPLETED})`);
+    if (options.partyRetryable) {
+      // receiptTimestamp IS NULL excludes Liberdus txs already in SUBMITTED/INCOMPLETED — they've been
+      // submitted to the Liberdus network and should not be retried by the party.
+      clauses.push("receiptTimestamp IS NULL");
+    }
   } else if (options?.status !== undefined) {
     clauses.push("status = @status");
     params.status = options.status;

--- a/shared/storage/transactiondb.ts
+++ b/shared/storage/transactiondb.ts
@@ -290,7 +290,7 @@ export function updateTransactionStatus(
       return "no_downgrade";
     }
 
-    // Use the passed-in nonce/timestamp if provided, otherwise fall back to the row's existing values
+    // Use the passed-in nonce/receiptTimestamp if provided, otherwise fall back to the row's existing values
     const effectiveTssSender = tssSender ?? current.tssSender;
     const effectiveNonce =
       receiptRef?.type === 'nonce' ? receiptRef.value : current.nonce;


### PR DESCRIPTION
refactor: improve Liberdus delivery reconciliation in observer

feat: skip Liberdus submitted txs from party retry queue

fix: restore unprocessed filter semantics and improve timeout reconciliation

docs: update BRIDGE_OUT flow and party retry behaviour in README
