### PR TITLE
chore: migrate @shardus/crypto-utils to lib-crypto-utils and ethers v5 to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each party index (1–5) runs a paired **observer** and **TSS party** process. B
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - PM2 (`npm install -g pm2`)
 
 ## Setup

--- a/observer/monitor/ethereum.ts
+++ b/observer/monitor/ethereum.ts
@@ -15,9 +15,9 @@ const BRIDGE_IN_EVENT_ABI =
 const BRIDGE_IN_FUNCTION_ABI =
   "function bridgeIn(address to, uint256 amount, uint256 _chainId, bytes32 txId) public";
 
-const BRIDGE_OUT_IFACE = new ethers.utils.Interface([BRIDGE_OUT_EVENT_ABI]);
-const BRIDGE_IN_IFACE = new ethers.utils.Interface([BRIDGE_IN_EVENT_ABI]);
-const BRIDGE_IN_CALL_IFACE = new ethers.utils.Interface([BRIDGE_IN_FUNCTION_ABI]);
+const BRIDGE_OUT_IFACE = new ethers.Interface([BRIDGE_OUT_EVENT_ABI]);
+const BRIDGE_IN_IFACE = new ethers.Interface([BRIDGE_IN_EVENT_ABI]);
+const BRIDGE_IN_CALL_IFACE = new ethers.Interface([BRIDGE_IN_FUNCTION_ABI]);
 
 const INITIAL_BATCH_SIZE = 2000;
 const MIN_BATCH_SIZE = 100;
@@ -122,7 +122,7 @@ export async function monitorEthereumBridgeOutQueryFilter(
 
       while (cursor <= toBlock) {
         const batchEnd = Math.min(cursor + batchSize - 1, toBlock);
-        let events: ethers.Event[];
+        let events: ethers.EventLog[];
 
         try {
           events = await observerChainRpc.withChainHttpProvider(
@@ -133,7 +133,7 @@ export async function monitorEthereumBridgeOutQueryFilter(
                 BRIDGE_OUT_IFACE,
                 provider
               );
-              return contract.queryFilter(contract.filters.BridgedOut(), cursor, batchEnd);
+              return contract.queryFilter(contract.filters.BridgedOut(), cursor, batchEnd) as Promise<ethers.EventLog[]>;
             },
             { maxRetries: 3, timeoutMs: 30_000 }
           );
@@ -185,9 +185,9 @@ export async function monitorEthereumBridgeOutQueryFilter(
           if (!event.args) continue;
 
           const targetAddress = event.args.targetAddress as string;
-          const amount = event.args.amount as ethers.BigNumber;
-          const parsedChainId = (event.args.chainId as ethers.BigNumber).toNumber();
-          const eventTimestamp = (event.args.timestamp as ethers.BigNumber).toNumber();
+          const amount = event.args.amount as bigint;
+          const parsedChainId = Number(event.args.chainId as bigint);
+          const eventTimestamp = Number(event.args.timestamp as bigint);
 
           if (parsedChainId !== chainId) continue;
 
@@ -233,7 +233,7 @@ export async function monitorEthereumBridgeOutQueryFilter(
           const tx: TransactionDB.Transaction = {
             txId,
             sender: toEthereumAddress(targetAddress),
-            value: ethers.utils.hexValue(amount),
+            value: ethers.toQuantity(amount),
             type: txType,
             txTimestamp: eventTimestamp * 1000,
             chainId,
@@ -326,7 +326,7 @@ export async function monitorEthereumBridgeInQueryFilter(
 
       while (cursor <= toBlock) {
         const batchEnd = Math.min(cursor + batchSize - 1, toBlock);
-        let events: ethers.Event[];
+        let events: ethers.EventLog[];
 
         try {
           events = await observerChainRpc.withChainHttpProvider(
@@ -337,7 +337,7 @@ export async function monitorEthereumBridgeInQueryFilter(
                 BRIDGE_IN_IFACE,
                 provider
               );
-              return contract.queryFilter(contract.filters.BridgedIn(), cursor, batchEnd);
+              return contract.queryFilter(contract.filters.BridgedIn(), cursor, batchEnd) as Promise<ethers.EventLog[]>;
             },
             { maxRetries: 3, timeoutMs: 30_000 }
           );
@@ -439,17 +439,17 @@ export async function monitorEthereumBridgeInQueryFilter(
           const txType = isVaultMode
             ? TransactionDB.TransactionType.BRIDGE_VAULT
             : TransactionDB.TransactionType.BRIDGE_IN;
-          const eventTimestamp = (event.args.timestamp as ethers.BigNumber).toNumber();
+          const eventTimestamp = Number(event.args.timestamp as bigint);
           const eventReceiptId = normalizeTxId(event.transactionHash);
 
           // BRIDGE_VAULT records are stored under the vault (source) chain ID, not the secondary chain.
           const earlyTx: TransactionDB.Transaction = {
             txId,
             sender: toEthereumAddress(event.args.to as string),
-            value: ethers.utils.hexValue(event.args.amount as ethers.BigNumber),
+            value: ethers.toQuantity(event.args.amount as bigint),
             type: txType,
             txTimestamp: eventTimestamp * 1000,
-            chainId: isVaultMode ? chainConfigsRaw.vaultChain!.chainId : (event.args.chainId as ethers.BigNumber).toNumber(),
+            chainId: isVaultMode ? chainConfigsRaw.vaultChain!.chainId : Number(event.args.chainId as bigint),
             receiptId: eventReceiptId,
             status: TransactionDB.TransactionStatus.COMPLETED,
             tssSender: chainConfig.tssSenderAddress.toLowerCase() || null,
@@ -633,10 +633,10 @@ export async function monitorFailedBridgeIns(targetChainId?: number): Promise<bo
       for (let blockNum = fromBlock + 1; blockNum <= toBlock && pendingMissingNonces.size > 0; blockNum++) {
         scannedThroughBlock = blockNum;
         const block = await observerChainRpc.withChainHttpProvider(
-          chainId, (p) => p.getBlockWithTransactions(blockNum), { maxRetries: 3 });
+          chainId, (p) => p.getBlock(blockNum, true), { maxRetries: 3 });
 
         if (block) {
-          for (const tx of block.transactions) {
+          for (const tx of block.prefetchedTransactions) {
             if (tx.from?.toLowerCase() !== tssSender) continue;
             if (tx.to?.toLowerCase() !== bridgeContract) continue;
 

--- a/observer/monitor/liberdus.ts
+++ b/observer/monitor/liberdus.ts
@@ -10,11 +10,11 @@ import { monitorState, saveMonitorState } from "./state";
 
 const BRIDGE_OUT_EVENT_ABI =
   "event BridgedOut(address indexed from, uint256 amount, address indexed targetAddress, uint256 indexed chainId, uint256 timestamp)";
-const BRIDGE_OUT_IFACE = new ethers.utils.Interface([BRIDGE_OUT_EVENT_ABI]);
+const BRIDGE_OUT_IFACE = new ethers.Interface([BRIDGE_OUT_EVENT_ABI]);
 
 type ParsedLiberdusBridgeTxBase = {
   sender: string;
-  value: ethers.BigNumber;
+  value: bigint;
   status: TransactionDB.TransactionStatus;
   txTimestamp: number;
 };
@@ -130,7 +130,7 @@ export async function monitorLiberdusTransactions(): Promise<void> {
             const tx: TransactionDB.Transaction = {
               txId,
               sender: toEthereumAddress(sender),
-              value: ethers.utils.hexValue(value),
+              value: ethers.toQuantity(value),
               type: TransactionDB.TransactionType.BRIDGE_IN,
               txTimestamp,
               chainId,
@@ -197,7 +197,7 @@ function parseLiberdusBridgeTx(
     if (type !== "transfer") return null;
 
     const txId = normalizeTxId(rawTxId);
-    const value = ethers.BigNumber.from("0x" + additionalInfo.amount.value);
+    const value = BigInt("0x" + additionalInfo.amount.value);
     const txTimestamp = Number(timestamp);
     if (!Number.isInteger(txTimestamp) || txTimestamp <= 0) return null;
 
@@ -288,14 +288,14 @@ async function verifyEvmBridgeOutSourceTx(
         if (parsed.name !== "BridgedOut") continue;
 
         const targetAddress = toEthereumAddress(parsed.args.targetAddress as string);
-        const amount = parsed.args.amount as ethers.BigNumber;
-        const chainId = (parsed.args.chainId as ethers.BigNumber).toNumber();
-        const timestampMs = (parsed.args.timestamp as ethers.BigNumber).toNumber() * 1000;
+        const amount = parsed.args.amount as bigint;
+        const chainId = Number(parsed.args.chainId as bigint);
+        const timestampMs = Number(parsed.args.timestamp as bigint) * 1000;
 
         if (targetAddress !== toEthereumAddress(tx.sender)) {
           return { ok: false, reason: "source_targetAddress_mismatch" };
         }
-        if (!amount.eq(ethers.BigNumber.from(tx.value))) {
+        if (amount !== BigInt(tx.value)) {
           return { ok: false, reason: "source_amount_mismatch" };
         }
         if (chainId !== tx.chainId) {
@@ -376,9 +376,9 @@ async function verifyLiberdusTx(
       return { ok: false, reason: "missing_liberdus_tx_amount" };
     }
     const rawAmount = amountValue.trim();
-    const actualAmount = ethers.BigNumber.from(rawAmount.startsWith("0x") ? rawAmount : `0x${rawAmount}`);
-    const expectedAmount = ethers.BigNumber.from(expected.amount);
-    if (!actualAmount.eq(expectedAmount)) {
+    const actualAmount = BigInt(rawAmount.startsWith("0x") ? rawAmount : `0x${rawAmount}`);
+    const expectedAmount = BigInt(expected.amount);
+    if (actualAmount !== expectedAmount) {
       return {
         ok: false,
         reason: `liberdus_tx_amount_mismatch(expected=${expectedAmount.toString()}, found=${actualAmount.toString()})`,

--- a/observer/verification.ts
+++ b/observer/verification.ts
@@ -10,7 +10,7 @@ const RETRY_DELAY_MS = 2000;
 
 const BRIDGE_IN_EVENT_ABI =
   "event BridgedIn(address indexed to, uint256 amount, uint256 indexed chainId, bytes32 indexed txId, uint256 timestamp)";
-const bridgeInterface = new ethers.utils.Interface([BRIDGE_IN_EVENT_ABI]);
+const bridgeInterface = new ethers.Interface([BRIDGE_IN_EVENT_ABI]);
 
 /**
  * Verify that a terminal transaction result matches its reported outcome.

--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.0",
     "@types/readline-sync": "^1.4.8",
-    "ethers": "^5.7.1",
+    "ethers": "^6.16.0",
     "nodemon": "^3.0.2",
-    "pm2": "^5.3.0",
+    "pm2": "^7.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@shardus/crypto-utils": "^4.1.6",
+    "@shardus/lib-crypto-utils": "^4.3.3",
     "axios": "^1.8.4",
     "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",

--- a/scripts/inject-liberdus-tx.ts
+++ b/scripts/inject-liberdus-tx.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import {ethers} from 'ethers'
-import * as crypto from '@shardus/crypto-utils'
+import * as crypto from '@shardus/lib-crypto-utils'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import axios from 'axios'
@@ -167,7 +167,7 @@ function verifySignedTx(tx: SignedLiberdusTx): boolean {
   const dataWithoutSign: TxObject = {...tx}
   delete dataWithoutSign.sign
   const message = crypto.hashObj(dataWithoutSign)
-  const recoveredAddress = ethers.utils.verifyMessage(message, sig)
+  const recoveredAddress = ethers.verifyMessage(message, sig)
   const recoveredShardusAddress = toShardusAddress(recoveredAddress)
   const isValid = recoveredShardusAddress.toLowerCase() === owner.toLowerCase()
   console.log(`  Verification - owner: ${owner}`)
@@ -394,7 +394,7 @@ async function main(): Promise<void> {
   console.log(`Vault Path Mode:   ${useDefaultSlotPath ? 'default-slot' : `party-${partyIdx}`}`)
 
   const hashMessage = crypto.hashObj(tx)
-  const digest = ethers.utils.hashMessage(hashMessage)
+  const digest = ethers.hashMessage(hashMessage)
   const unsignedTxId = crypto.hashObj(tx)
   const channelId =
     requireStringFlag(flags, 'channel-id') ||
@@ -436,7 +436,7 @@ async function main(): Promise<void> {
     s: signed.s,
     v: signed.v,
   }
-  const serializedSignature = ethers.utils.joinSignature(signature)
+  const serializedSignature = ethers.Signature.from(signature).serialized
 
   const signedTx: SignedLiberdusTx = {
     ...tx,

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import axios, {AxiosResponse} from 'axios'
 import http from 'http'
 import https from 'https'
-import * as crypto from '@shardus/crypto-utils'
+import * as crypto from '@shardus/lib-crypto-utils'
 import {
   ChainConfig,
   ChainConfigs,
@@ -30,7 +30,23 @@ import {gossipBridgeIn} from './gossip'
 import * as TransactionDB from '../shared/storage/transactiondb'
 import {Transaction, TransactionStatus, TransactionType, ExecutionHistoryEntry} from '../shared/storage/transactiondb'
 
-const {utils: ethersUtils} = ethers
+const ethersUtils = {
+  parseUnits: ethers.parseUnits,
+  formatEther: ethers.formatEther,
+  formatUnits: ethers.formatUnits,
+  verifyMessage: ethers.verifyMessage,
+  keccak256: ethers.keccak256,
+  computeAddress: ethers.computeAddress,
+  Interface: ethers.Interface,
+  joinSignature: (sig: {r: string; s: string; v: number}) =>
+    ethers.Signature.from(sig).serialized,
+  recoverPublicKey: (digest: string, sig: {r: string; s: string; v: number}) =>
+    ethers.SigningKey.recoverPublicKey(digest, ethers.Signature.from(sig)),
+  serializeTransaction: (tx: ethers.TransactionLike, sig?: {r: string; s: string; v: number}) =>
+    sig
+      ? ethers.Transaction.from({...tx, signature: ethers.Signature.from(sig)}).serialized
+      : ethers.Transaction.from(tx).unsignedSerialized,
+}
 
 ;(function enableTimestampedConsoleLogs() {
   const methods: Array<'log' | 'info' | 'warn' | 'error'> = ['log', 'info', 'warn', 'error']
@@ -55,16 +71,16 @@ interface ChainState {
   contract?: ethers.Contract
   // Bridge contract state (cooldown, max amount, last bridge-in time)
   bridgeInCooldown: number         // seconds
-  maxBridgeInAmount: ethers.BigNumber
+  maxBridgeInAmount: bigint
   lastBridgeInTime: number         // unix timestamp in seconds
-  // Precomputed BigNumber values of gasConfig.gasPriceTiers (avoids parseUnits per-tx)
-  gasPriceTiersBN: ethers.BigNumber[]
+  // Precomputed bigint values of gasConfig.gasPriceTiers (avoids parseUnits per-tx)
+  gasPriceTiersBN: bigint[]
 }
 
 interface TransactionQueueItem {
   receipt: any
   from: string
-  value: ethers.BigNumber | bigint
+  value: bigint
   txId: string
   type: 'tokenToCoin' | 'coinToToken' | 'vaultBridge'
   chainId: number // Add chainId to track which chain this transaction belongs to
@@ -198,7 +214,7 @@ const chainStateByChainId: Map<number, ChainState> = new Map(
     {
       config,
       bridgeInCooldown: 0,
-      maxBridgeInAmount: ethers.BigNumber.from(0),
+      maxBridgeInAmount: BigInt(0),
       lastBridgeInTime: 0,
       gasPriceTiersBN: (config.gasConfig?.gasPriceTiers ?? []).map((t) =>
         ethersUtils.parseUnits(t.toString(), 'gwei'),
@@ -238,9 +254,9 @@ async function fetchBridgeState(
           { maxRetries: 3 },
         ),
       ])
-      chainState.bridgeInCooldown = BRIDGE_CONTRACT_IFACE.decodeFunctionResult('bridgeInCooldown', cooldownRaw)[0].toNumber()
+      chainState.bridgeInCooldown = Number(BRIDGE_CONTRACT_IFACE.decodeFunctionResult('bridgeInCooldown', cooldownRaw)[0])
       chainState.maxBridgeInAmount = BRIDGE_CONTRACT_IFACE.decodeFunctionResult('maxBridgeInAmount', maxAmountRaw)[0]
-      chainState.lastBridgeInTime = BRIDGE_CONTRACT_IFACE.decodeFunctionResult('lastBridgeInTime', lastTimeRaw)[0].toNumber()
+      chainState.lastBridgeInTime = Number(BRIDGE_CONTRACT_IFACE.decodeFunctionResult('lastBridgeInTime', lastTimeRaw)[0])
       const lastBridgeInStr = chainState.lastBridgeInTime > 0
         ? new Date(chainState.lastBridgeInTime * 1000).toISOString()
         : 'never'
@@ -256,7 +272,7 @@ async function fetchBridgeState(
         provider.call({to: contractAddr, data: BRIDGE_CONTRACT_IFACE.encodeFunctionData('lastBridgeInTime')}),
         { maxRetries: 3 },
       )
-      chainState.lastBridgeInTime = BRIDGE_CONTRACT_IFACE.decodeFunctionResult('lastBridgeInTime', lastTimeRaw)[0].toNumber()
+      chainState.lastBridgeInTime = Number(BRIDGE_CONTRACT_IFACE.decodeFunctionResult('lastBridgeInTime', lastTimeRaw)[0])
       const lastBridgeInStr = chainState.lastBridgeInTime > 0
         ? new Date(chainState.lastBridgeInTime * 1000).toISOString()
         : 'never'
@@ -266,7 +282,7 @@ async function fetchBridgeState(
         provider.call({to: contractAddr, data: BRIDGE_CONTRACT_IFACE.encodeFunctionData('bridgeInCooldown')}),
         { maxRetries: 3 },
       )
-      chainState.bridgeInCooldown = BRIDGE_CONTRACT_IFACE.decodeFunctionResult('bridgeInCooldown', cooldownRaw)[0].toNumber()
+      chainState.bridgeInCooldown = Number(BRIDGE_CONTRACT_IFACE.decodeFunctionResult('bridgeInCooldown', cooldownRaw)[0])
       console.log(`Bridge bridgeInCooldown fetched for ${chainState.config.name}: ${chainState.bridgeInCooldown}s`)
     } else if (fields === 'maxBridgeInAmount') {
       const maxAmountRaw = await chainRpcConfig.withChainHttpProvider(chainId, (provider) =>
@@ -288,7 +304,7 @@ async function waitForBridgeCooldown(
   chainName: string,
   txId: string,
   txHash: string,
-): Promise<{ receipt: ethers.providers.TransactionReceipt | null; outcome: ProcessOutcome | null }> {
+): Promise<{ receipt: ethers.TransactionReceipt | null; outcome: ProcessOutcome | null }> {
   const latestBlock = await chainRpcConfig.withChainHttpProvider(
     chainState.config.chainId,
     (provider) => provider.getBlock('latest'),
@@ -347,15 +363,15 @@ async function waitForBridgeCooldown(
 
 async function checkMaxBridgeAmount(
   chainState: ChainState,
-  value: ethers.BigNumber,
+  value: bigint,
   skipRefetch = false,
 ): Promise<boolean> {
-  if (value.lte(chainState.maxBridgeInAmount)) return true
+  if (value <= chainState.maxBridgeInAmount) return true
   if (skipRefetch) return false
   // Cached check failed — re-fetch in case the limit was raised on-chain
   console.log(`[bridge-limits] Cached maxBridgeInAmount check failed, re-fetching for chain ${chainState.config.chainId}`)
   await fetchBridgeState(chainState.config.chainId, 'maxBridgeInAmount')
-  return value.lte(chainState.maxBridgeInAmount)
+  return value <= chainState.maxBridgeInAmount
 }
 
 
@@ -657,7 +673,7 @@ async function pollPendingTransactionsFromLocalDB(): Promise<void> {
             ? 'vaultBridge'
             : 'tokenToCoin'
 
-      const value = ethers.BigNumber.from(tx.value)
+      const value = BigInt(tx.value)
 
       const txData: TransactionQueueItem = {
         receipt: null as any,
@@ -739,19 +755,22 @@ async function getLatestChainNonce(chainId: number, tssSender: string): Promise<
     chainId, (provider) => provider.getTransactionCount(tssSender), { maxRetries: 3 })
 }
 
-async function getChainTransactionReceipt(chainId: number, txHash: string): Promise<ethers.providers.TransactionReceipt | null> {
+async function getChainTransactionReceipt(chainId: number, txHash: string): Promise<ethers.TransactionReceipt | null> {
   return chainRpcConfig.withChainHttpProvider(
     chainId, (provider) => provider.getTransactionReceipt(txHash), { maxRetries: 3 })
 }
 
 // Fetches gas price from a fixed RPC URL so all parties query the same endpoint,
 // avoiding payload divergence from different Chainlist RPCs returning different values.
-async function getGasPriceFromFixedRpc(rpcUrl: string, maxRetries = 3): Promise<ethers.BigNumber> {
-  const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+async function getGasPriceFromFixedRpc(rpcUrl: string, maxRetries = 3): Promise<bigint> {
+  const provider = new ethers.JsonRpcProvider(rpcUrl)
   let lastError: unknown
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await provider.getGasPrice()
+      const feeData = await provider.getFeeData()
+      const gasPrice = feeData.gasPrice
+      if (gasPrice == null) throw new Error('gasPrice not available from fee data')
+      return gasPrice
     } catch (err) {
       lastError = err
       if (attempt < maxRetries) {
@@ -1070,7 +1089,7 @@ async function injectEthereumTx(
   try {
     const txResponse = await chainRpcConfig.withChainHttpProvider(
       chainId,
-      (provider) => provider.sendTransaction(signedTx),
+      (provider) => provider.broadcastTransaction(signedTx),
       { maxRetries: 1, timeoutMs: TSS_PARTY_SEND_TX_TIMEOUT_MS },
     )
     console.log('BridgeIn transaction sent successfully!', txResponse.hash)
@@ -1110,14 +1129,14 @@ async function injectLiberdusTx(
 
 async function processCoinToToken(
   to: string,
-  value: ethers.BigNumber,
+  value: bigint,
   txId: string,
   targetChainId: number,
   txTimestampMs: number,
   isRefund?: boolean,
   revertReason?: string,
 ): Promise<ProcessOutcome> {
-  value = ethers.BigNumber.from(value)
+  value = BigInt(value)
   console.log('Processing coin to token transaction', {
     to,
     value: value.toString(),
@@ -1142,9 +1161,9 @@ async function processCoinToToken(
   // Operator-imposed local limit check — fires before the on-chain check
   if (!isRefund) {
     const maxBridgeInAmountConfig = chainConfigs.liberdusBridgeGuards.maxBridgeInAmount
-    const localMaxBridgeAmount = maxBridgeInAmountConfig !== "0" ? ethers.utils.parseEther(maxBridgeInAmountConfig) : null
+    const localMaxBridgeAmount = maxBridgeInAmountConfig !== "0" ? ethers.parseEther(maxBridgeInAmountConfig) : null
     console.log(`[bridge-guards] BRIDGE_IN on ${targetChainName}: amount ${ethersUtils.formatEther(value)} LIB, local limit ${maxBridgeInAmountConfig !== "0" ? maxBridgeInAmountConfig : 'none'} LIB`)
-    if (localMaxBridgeAmount && value.gt(localMaxBridgeAmount)) {
+    if (localMaxBridgeAmount !== null && value > localMaxBridgeAmount) {
       console.warn(`[bridge-guards] BRIDGE_IN on ${targetChainName}: amount ${ethersUtils.formatEther(value)} LIB exceeds local limit ${maxBridgeInAmountConfig} LIB — initiating refund`)
       const revertReason = `Amount ${ethersUtils.formatEther(value)} LIB exceeds local BRIDGE_IN limit of ${maxBridgeInAmountConfig} LIB`
       return processTokenToCoin(to, value, txId, targetChainId, txTimestampMs, true, revertReason)
@@ -1272,7 +1291,7 @@ async function processCoinToToken(
 
   // Apply gas price logic based on chain configuration
   for (const tierGwei of chainState.gasPriceTiersBN) {
-    if (currentGasPrice.lte(tierGwei)) {
+    if (currentGasPrice <= tierGwei) {
       currentGasPrice = tierGwei
       break
     }
@@ -1399,7 +1418,7 @@ async function processCoinToToken(
     }, n, observerUrl)
   }
 
-  let receipt: ethers.providers.TransactionReceipt | null = null
+  let receipt: ethers.TransactionReceipt | null = null
   try {
     receipt = await getChainTransactionReceipt(targetChainId, txHash)
     if (!receipt) {
@@ -1453,13 +1472,13 @@ async function processCoinToToken(
 
 async function processVaultBridge(
   to: string,
-  value: ethers.BigNumber,
+  value: bigint,
   txId: string,
   sourceChainId: number,
   destinationChainId: number,
   txTimestampMs: number,
 ): Promise<ProcessOutcome> {
-  value = ethers.BigNumber.from(value)
+  value = BigInt(value)
   console.log('Processing vault bridge transaction', {
     to,
     value: value.toString(),
@@ -1612,7 +1631,7 @@ async function processVaultBridge(
 
   // Apply gas price logic based on destination chain configuration
   for (const tierGwei of destChainState.gasPriceTiersBN) {
-    if (currentGasPrice.lte(tierGwei)) {
+    if (currentGasPrice <= tierGwei) {
       currentGasPrice = tierGwei
       break
     }
@@ -1739,7 +1758,7 @@ async function processVaultBridge(
     }, n, observerUrl)
   }
 
-  let receipt: ethers.providers.TransactionReceipt | null = null
+  let receipt: ethers.TransactionReceipt | null = null
   try {
     receipt = await getChainTransactionReceipt(destinationChainId, txHash)
     if (!receipt) {
@@ -1811,11 +1830,11 @@ async function processTokenToCoin(
 
   // Operator-imposed local limit check — only on non-refund calls
   if (!isRefund) {
-    const valueBN = ethers.BigNumber.from(value.toHexString())
+    const valueBN = value
     const maxBridgeOutAmountConfig = chainConfigs.liberdusBridgeGuards.maxBridgeOutAmount
-    const localMaxBridgeAmount = maxBridgeOutAmountConfig !== "0" ? ethers.utils.parseEther(maxBridgeOutAmountConfig) : null
+    const localMaxBridgeAmount = maxBridgeOutAmountConfig !== "0" ? ethers.parseEther(maxBridgeOutAmountConfig) : null
     console.log(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB, local limit ${maxBridgeOutAmountConfig !== "0" ? maxBridgeOutAmountConfig : 'none'} LIB`)
-    if (localMaxBridgeAmount && valueBN.gt(localMaxBridgeAmount)) {
+    if (localMaxBridgeAmount !== null && valueBN > localMaxBridgeAmount) {
       console.warn(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB exceeds local limit ${maxBridgeOutAmountConfig} LIB — initiating refund`)
       const revertReason = `Amount ${ethersUtils.formatEther(valueBN)} LIB exceeds local BRIDGE_OUT limit of ${maxBridgeOutAmountConfig} LIB`
       // Observer stores the BRIDGE_OUT targetAddress as transaction.sender; refund assumes it matches the original sender.
@@ -1863,7 +1882,7 @@ async function processTokenToCoin(
   )
   console.log('Transaction:', tx)
   const hashMessage = crypto.hashObj(tx)
-  let digest = ethersUtils.hashMessage(hashMessage)
+  let digest = ethers.hashMessage(hashMessage)
   const channelId = deriveDeterministicChannelId(normalizeTxId(txId), txTimestampMs)
   const channelPassword = deriveDeterministicChannelPassword(channelId, cryptoInitKey)
 
@@ -2345,7 +2364,7 @@ async function main(): Promise<void> {
       if (validTx.type === 'coinToToken') {
         processPromise = processCoinToToken(
           validTx.from,
-          validTx.value as ethers.BigNumber,
+          validTx.value as bigint,
           validTx.txId,
           validTx.chainId,
           validTx.txTimestamp,
@@ -2354,7 +2373,7 @@ async function main(): Promise<void> {
         console.log('Processing token to coin transaction', validTx)
         processPromise = processTokenToCoin(
           validTx.from,
-          validTx.value as ethers.BigNumber,
+          validTx.value as bigint,
           validTx.txId,
           validTx.chainId,
           validTx.txTimestamp,
@@ -2363,7 +2382,7 @@ async function main(): Promise<void> {
         console.log('Processing vault bridge (EVM-to-EVM) transaction', validTx)
         processPromise = processVaultBridge(
           validTx.from,
-          validTx.value as ethers.BigNumber,
+          validTx.value as bigint,
           validTx.txId,
           validTx.chainId,
           chainConfigs.secondaryChainConfig!.chainId,

--- a/shared/chainRpc.ts
+++ b/shared/chainRpc.ts
@@ -17,7 +17,7 @@ export interface InitializedRpcConfig {
   invalidateChainHttpProvider: (chainId: number) => void
   withChainHttpProvider: <T>(
     chainId: number,
-    fn: (provider: ethers.providers.JsonRpcProvider) => Promise<T>,
+    fn: (provider: ethers.JsonRpcProvider) => Promise<T>,
     options?: Omit<WithCachedRetryOptions, 'fallbackRpcUrl'>,
   ) => Promise<T>
 }
@@ -25,7 +25,7 @@ export interface InitializedRpcConfig {
 export function buildChainProviderMap<T>(
   chains: ChainConfig[],
   rpcConfig: InitializedRpcConfig,
-  buildEntry: (config: ChainConfig, provider: ethers.providers.JsonRpcProvider) => T,
+  buildEntry: (config: ChainConfig, provider: ethers.JsonRpcProvider) => T,
 ): Map<number, T> {
   const entries = new Map<number, T>()
 
@@ -91,7 +91,7 @@ export function initializeChainRpcConfig(
 
   async function withChainHttpProvider<T>(
     chainId: number,
-    fn: (provider: ethers.providers.JsonRpcProvider) => Promise<T>,
+    fn: (provider: ethers.JsonRpcProvider) => Promise<T>,
     providerOptions: Omit<WithCachedRetryOptions, 'fallbackRpcUrl'> = {},
   ): Promise<T> {
     return withCachedHttpProvider(chainId, getHttpRpcUrlsForChain(chainId), fn, {

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -106,8 +106,8 @@ function validateBridgeGuardAmount(value: unknown, fieldName: keyof LiberdusBrid
     throw new Error(`[config] liberdusBridgeGuards.${fieldName} must be a non-empty LIB amount string; use "0" to disable`)
   }
   try {
-    const parsed = ethers.utils.parseEther(value)
-    if (parsed.lt(0)) {
+    const parsed = ethers.parseEther(value)
+    if (parsed < 0n) {
       throw new Error('amount must be non-negative')
     }
   } catch (e) {

--- a/shared/lib/httpProviderHelper.ts
+++ b/shared/lib/httpProviderHelper.ts
@@ -2,7 +2,6 @@ import { ethers } from "ethers";
 import { markUrlFailed, pickAvailableUrlFromList, shouldBlacklistForError } from "./rpcUrls";
 import { toNetworkChainId } from "../config";
 
-const { providers } = ethers;
 export interface GetProviderOptions {
   fallbackRpcUrl?: string;
   chainId?: number;
@@ -40,7 +39,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs?: number): Promise<
 export function getHttpProviderForChain(
   httpUrls: string[],
   options: GetProviderOptions = {},
-): ethers.providers.JsonRpcProvider {
+): ethers.JsonRpcProvider {
   const url =
     httpUrls.length > 0 ? pickAvailableUrlFromList(httpUrls) : options.fallbackRpcUrl;
   if (!url) throw new Error("No HTTP RPC URL available and no fallback");
@@ -49,13 +48,13 @@ export function getHttpProviderForChain(
     options.chainId != null
       ? { chainId: toNetworkChainId(options.chainId), name: "unknown" }
       : undefined;
-  return new providers.JsonRpcProvider(url, network);
+  return new ethers.JsonRpcProvider(url, network);
 }
 
 
 export async function withHttpProviderRetry<T>(
   httpUrls: string[],
-  fn: (provider: ethers.providers.JsonRpcProvider) => Promise<T>,
+  fn: (provider: ethers.JsonRpcProvider) => Promise<T>,
   options: WithRetryOptions = {},
 ): Promise<T> {
   const maxRetries = Math.max(1, options.maxRetries ?? 3);
@@ -88,7 +87,7 @@ export async function withHttpProviderRetry<T>(
   throw lastError;
 }
 
-const providerCache = new Map<number, { provider: ethers.providers.JsonRpcProvider; url: string }>();
+const providerCache = new Map<number, { provider: ethers.JsonRpcProvider; url: string }>();
 
 export function invalidateCachedProvider(chainId: number): void {
   providerCache.delete(chainId);
@@ -97,7 +96,7 @@ export function invalidateCachedProvider(chainId: number): void {
 export async function withCachedHttpProvider<T>(
   chainId: number,
   httpUrls: string[],
-  fn: (provider: ethers.providers.JsonRpcProvider) => Promise<T>,
+  fn: (provider: ethers.JsonRpcProvider) => Promise<T>,
   options: WithCachedRetryOptions = {}
 ): Promise<T> {
   const maxRetries = Math.max(1, options.maxRetries ?? 3);

--- a/shared/utils/evmBridgeInGossip.ts
+++ b/shared/utils/evmBridgeInGossip.ts
@@ -5,7 +5,7 @@ import { toEthereumAddress } from "./transformAddress";
 const BRIDGE_IN_FUNCTION_ABI =
   "function bridgeIn(address to, uint256 amount, uint256 _chainId, bytes32 txId) public";
 
-const bridgeInIface = new ethers.utils.Interface([BRIDGE_IN_FUNCTION_ABI]);
+const bridgeInIface = new ethers.Interface([BRIDGE_IN_FUNCTION_ABI]);
 
 export interface EVMBridgeInGossipPayload {
   txId: string;
@@ -47,7 +47,7 @@ export function verifyEVMBridgeInGossipPayload(
       return { ok: false, reason: "invalid_nonce" };
     }
 
-    const parsed = ethers.utils.parseTransaction(normalized.signedTx);
+    const parsed = ethers.Transaction.from(normalized.signedTx);
     const parsedHash = normalizeTxId(parsed.hash ?? "");
     if (parsedHash !== normalized.receiptId) {
       return { ok: false, reason: "receiptId_mismatch" };

--- a/shared/utils/liberdusBridgeInGossip.ts
+++ b/shared/utils/liberdusBridgeInGossip.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { ethers } from "ethers";
-import * as crypto from "@shardus/crypto-utils";
+import * as crypto from "@shardus/lib-crypto-utils";
 import { toShardusAddress } from "./transformAddress";
 import { isNormalizedTxId, normalizeTxId } from "./transformTxId";
 import { DEFAULT_SHARDUS_CRYPTO_HASH_KEY } from "../../tss-tools/lib/channelId";
@@ -75,7 +75,7 @@ export function verifyLiberdusBridgeInGossipPayload(
     const unsignedTx = { ...parsedSignedTx };
     delete unsignedTx.sign;
     const message = crypto.hashObj(unsignedTx);
-    const recoveredAddress = ethers.utils.verifyMessage(message, parsedSignedTx.sign.sig);
+    const recoveredAddress = ethers.verifyMessage(message, parsedSignedTx.sign.sig);
     const recoveredShardusAddress = toShardusAddress(recoveredAddress);
     const ownerShardusAddress = toShardusAddress(parsedSignedTx.sign.owner);
     if (recoveredShardusAddress.toLowerCase() !== ownerShardusAddress.toLowerCase()) {

--- a/tss-tools/lib/bnbTss.ts
+++ b/tss-tools/lib/bnbTss.ts
@@ -105,7 +105,7 @@ export type VerifyOptions = BasePartyOptions & {
 
 export type SignEthereumTxOptions = BasePartyOptions & {
   txFile?: string
-  tx?: ethers.UnsignedTransaction
+  tx?: ethers.TransactionLike
   channelId?: string
   channelPassword?: string
   signDiscoveryTimeout?: string
@@ -1126,7 +1126,7 @@ export function validatePartyVaults(options: Omit<BasePartyOptions, 'chainId'> &
     const derived = derivePubkey({...options, chainId, format: 'all'}) as DerivedPubkeyAll;
     const expectedAddress = options.expectedAddressesByChainId?.[chainId];
     if (expectedAddress) {
-      if (ethers.utils.getAddress(derived.ethereum_address) !== ethers.utils.getAddress(expectedAddress)) {
+      if (ethers.getAddress(derived.ethereum_address) !== ethers.getAddress(expectedAddress)) {
         throw new Error(
           `BNB TSS address mismatch for chain ${chainId}: derived ${derived.ethereum_address}, expected ${expectedAddress}`,
         );
@@ -1147,14 +1147,14 @@ function toMessageDecimal(digestHex: string): string {
 }
 
 function deriveRecoveryId(digestHex: string, signature: {r: string; s: string}, expectedAddress: string): number {
-  const normalized = ethers.utils.getAddress(expectedAddress);
+  const normalized = ethers.getAddress(expectedAddress);
   for (const recoveryParam of [0, 1]) {
-    const recovered = ethers.utils.recoverAddress(digestHex, {
+    const recovered = ethers.recoverAddress(digestHex, ethers.Signature.from({
       r: signature.r,
       s: signature.s,
-      recoveryParam,
-    });
-    if (ethers.utils.getAddress(recovered) === normalized) {
+      v: 27 + recoveryParam,
+    }));
+    if (ethers.getAddress(recovered) === normalized) {
       return recoveryParam;
     }
   }
@@ -1197,7 +1197,7 @@ export async function signDigest(options: SignEthereumTxOptions & {digest: strin
   const signatureHex = extractSignatureHex(`${result.stdout}\n${result.stderr}`);
   const signature = parseCompactSignature(signatureHex);
   const derived = derivePubkey({...options, signerRoot, tssRoot, format: 'all'}) as DerivedPubkeyAll;
-  const ethereumAddress = ethers.utils.getAddress(derived.ethereum_address);
+  const ethereumAddress = ethers.getAddress(derived.ethereum_address);
   const recoveryParam = deriveRecoveryId(options.digest, signature, ethereumAddress);
   return {
     digest: options.digest,
@@ -1214,21 +1214,17 @@ export async function signDigest(options: SignEthereumTxOptions & {digest: strin
 }
 
 export async function signEthereumTransaction(options: SignEthereumTxOptions = {} as SignEthereumTxOptions): Promise<SignEthereumTransactionResult> {
-  const digest = ethers.utils.keccak256(ethers.utils.serializeTransaction(options.tx));
+  const digest = ethers.keccak256(ethers.Transaction.from(options.tx).unsignedSerialized);
   const signed = await signDigest({...options, digest});
-  const signature = {
-    r: signed.r,
-    s: signed.s,
-    v: signed.v,
-  };
-  const signedTx = ethers.utils.serializeTransaction(options.tx, signature);
-  const recovered = ethers.utils.recoverAddress(digest, signature);
-  if (ethers.utils.getAddress(recovered) !== signed.ethereumAddress) {
+  const signature = ethers.Signature.from({ r: signed.r, s: signed.s, v: signed.v });
+  const signedTx = ethers.Transaction.from({ ...options.tx, signature }).serialized;
+  const recovered = ethers.recoverAddress(digest, signature);
+  if (ethers.getAddress(recovered) !== signed.ethereumAddress) {
     throw new Error(`Recovered signer ${recovered} does not match ${signed.ethereumAddress}`);
   }
   return {
     signedTx,
-    txHash: ethers.utils.keccak256(signedTx),
+    txHash: ethers.keccak256(signedTx),
     digest,
     ...signed,
   };

--- a/tss-tools/sign-ethereum-tx.ts
+++ b/tss-tools/sign-ethereum-tx.ts
@@ -97,9 +97,9 @@ function parseArgs(argv: string[]): bnbTss.SignEthereumTxOptions & {chainId: num
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
-  const tx = JSON.parse(fs.readFileSync(options.txFile, 'utf8')) as ethers.UnsignedTransaction;
-  const unsignedTx = ethers.utils.serializeTransaction(tx);
-  const txHash = ethers.utils.keccak256(unsignedTx);
+  const tx = JSON.parse(fs.readFileSync(options.txFile, 'utf8')) as ethers.TransactionLike;
+  const unsignedTx = ethers.Transaction.from(tx).unsignedSerialized;
+  const txHash = ethers.keccak256(unsignedTx);
   const txTimestampMs = Math.floor(Date.now() / SIGN_CHANNEL_TIME_BUCKET_MS) * SIGN_CHANNEL_TIME_BUCKET_MS;
   const channelId =
     options.channelId ||


### PR DESCRIPTION


- Replace @shardus/crypto-utils@4.1.6 with @shardus/lib-crypto-utils@4.3.3 (old package required node 18, incompatible with node 20)
- ethers v5 → v6 and pm2 upgrade were pulled in via `npm audit fix --force` to resolve 29 vulnerabilities (2 critical, 6 high) in the dependency tree
- Migrated all ethers v5 APIs to v6 across the codebase:
  - ethers.providers.JsonRpcProvider → ethers.JsonRpcProvider
  - ethers.utils.Interface → ethers.Interface
  - ethers.BigNumber → native bigint
  - ethers.utils.parseEther/keccak256/getAddress/etc → top-level ethers.*
  - ethers.utils.serializeTransaction → ethers.Transaction.from(...)
  - ethers.utils.recoverAddress → ethers.recoverAddress
  - ethers.Event → ethers.EventLog
  - provider.getBlockWithTransactions → provider.getBlock(n, true)
  - provider.getGasPrice → provider.getFeeData().gasPrice
  - provider.sendTransaction → provider.broadcastTransaction