### PR TITLE
Require public recipient account

### DIFF
--- a/chain-config.dev.json
+++ b/chain-config.dev.json
@@ -52,6 +52,7 @@
   "liberdusNetworkId": "52d545708708f41ed7162ff641626de0568b2bd098e5640233ce4a387d9c5aa8",
   "liberdusBridgeGuards": {
     "maxBridgeInAmount": "0",
+    "minBridgeOutAmount": "0",
     "maxBridgeOutAmount": "0",
     "requirePublicRecipientAccount": true
   }

--- a/chain-config.dev.json
+++ b/chain-config.dev.json
@@ -53,6 +53,6 @@
   "liberdusBridgeGuards": {
     "maxBridgeInAmount": "0",
     "maxBridgeOutAmount": "0",
-    "enforceRecipientExists": true
+    "requirePublicRecipientAccount": true
   }
 }

--- a/chain-config.json
+++ b/chain-config.json
@@ -52,6 +52,7 @@
   "liberdusNetworkId": "52d545708708f41ed7162ff641626de0568b2bd098e5640233ce4a387d9c5aa8",
   "liberdusBridgeGuards": {
     "maxBridgeInAmount": "0",
+    "minBridgeOutAmount": "0",
     "maxBridgeOutAmount": "0",
     "requirePublicRecipientAccount": true
   }

--- a/chain-config.json
+++ b/chain-config.json
@@ -53,6 +53,6 @@
   "liberdusBridgeGuards": {
     "maxBridgeInAmount": "0",
     "maxBridgeOutAmount": "0",
-    "enforceRecipientExists": true
+    "requirePublicRecipientAccount": true
   }
 }

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -1831,9 +1831,17 @@ async function processTokenToCoin(
   // Operator-imposed local limit check — only on non-refund calls
   if (!isRefund) {
     const valueBN = ethers.BigNumber.from(value.toHexString())
+    const minBridgeOutAmountConfig = chainConfigs.liberdusBridgeGuards.minBridgeOutAmount
     const maxBridgeOutAmountConfig = chainConfigs.liberdusBridgeGuards.maxBridgeOutAmount
+    const localMinBridgeAmount = minBridgeOutAmountConfig !== "0" ? ethers.utils.parseEther(minBridgeOutAmountConfig) : null
     const localMaxBridgeAmount = maxBridgeOutAmountConfig !== "0" ? ethers.utils.parseEther(maxBridgeOutAmountConfig) : null
-    console.log(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB, local limit ${maxBridgeOutAmountConfig !== "0" ? maxBridgeOutAmountConfig : 'none'} LIB`)
+    console.log(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB, local min ${minBridgeOutAmountConfig !== "0" ? minBridgeOutAmountConfig : 'none'} LIB, local max ${maxBridgeOutAmountConfig !== "0" ? maxBridgeOutAmountConfig : 'none'} LIB`)
+    if (localMinBridgeAmount && valueBN.lt(localMinBridgeAmount)) {
+      console.warn(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB is below local minimum ${minBridgeOutAmountConfig} LIB — initiating refund`)
+      const revertReason = `Amount ${ethersUtils.formatEther(valueBN)} LIB is below local BRIDGE_OUT minimum of ${minBridgeOutAmountConfig} LIB`
+      // Observer stores the BRIDGE_OUT targetAddress as transaction.sender; refund assumes it matches the original sender.
+      return processCoinToToken(to, valueBN, txId, sourceChainId, txTimestampMs, true, revertReason)
+    }
     if (localMaxBridgeAmount && valueBN.gt(localMaxBridgeAmount)) {
       console.warn(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: amount ${ethersUtils.formatEther(valueBN)} LIB exceeds local limit ${maxBridgeOutAmountConfig} LIB — initiating refund`)
       const revertReason = `Amount ${ethersUtils.formatEther(valueBN)} LIB exceeds local BRIDGE_OUT limit of ${maxBridgeOutAmountConfig} LIB`

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -1841,13 +1841,19 @@ async function processTokenToCoin(
       return processCoinToToken(to, valueBN, txId, sourceChainId, txTimestampMs, true, revertReason)
     }
 
-    if (chainConfigs.liberdusBridgeGuards.enforceRecipientExists) {
+    if (chainConfigs.liberdusBridgeGuards.requirePublicRecipientAccount) {
       const shardusTo = toShardusAddress(to)
       const accountCheck = await checkLiberdusAccountExists(shardusTo)
       console.log(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: recipient account ${shardusTo} — ${accountCheck}`)
       if (accountCheck === 'not-found') {
         console.warn(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: recipient ${shardusTo} does not exist on Liberdus network — initiating refund`)
         const revertReason = `Recipient account does not exist on Liberdus network`
+        // Observer stores the BRIDGE_OUT targetAddress as transaction.sender; refund assumes it matches the original sender.
+        return processCoinToToken(to, valueBN, txId, sourceChainId, txTimestampMs, true, revertReason)
+      }
+      if (accountCheck === 'private') {
+        console.warn(`[bridge-guards] BRIDGE_OUT from ${sourceChainName}: recipient ${shardusTo} is a private Liberdus account — initiating refund`)
+        const revertReason = `Recipient account is private on Liberdus network`
         // Observer stores the BRIDGE_OUT targetAddress as transaction.sender; refund assumes it matches the original sender.
         return processCoinToToken(to, valueBN, txId, sourceChainId, txTimestampMs, true, revertReason)
       }
@@ -2213,7 +2219,7 @@ async function getLiberdusAccountBalance(address: string): Promise<string | null
   return balance
 }
 
-async function checkLiberdusAccountExists(shardusAddress: string): Promise<'exists' | 'not-found' | 'error'> {
+async function checkLiberdusAccountExists(shardusAddress: string): Promise<'exists' | 'private' | 'not-found' | 'error'> {
   const url = proxyServerHost + '/account/' + shardusAddress
   const maxAttempts = 3
   let lastResult: 'not-found' | 'error' = 'error'
@@ -2221,7 +2227,8 @@ async function checkLiberdusAccountExists(shardusAddress: string): Promise<'exis
     try {
       const response = await axios.get(url, { timeout: 3000 })
       if (response.status === 200) {
-        if (response.data?.account != null) return 'exists'
+        const account = response.data?.account
+        if (account != null) return account.private === true ? 'private' : 'exists'
         lastResult = 'not-found'
       } else {
         lastResult = 'error'

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -33,7 +33,7 @@ export function requireSigningChainConfig(
 export interface LiberdusBridgeGuards {
   maxBridgeInAmount: string       // LIB amount — operator-imposed max for BRIDGE_IN txs (Liberdus → EVM); "0" disables the limit
   maxBridgeOutAmount: string      // LIB amount — operator-imposed max for BRIDGE_OUT txs (EVM → Liberdus); "0" disables the limit
-  enforceRecipientExists: boolean // When true, refunds BRIDGE_OUT txs whose Liberdus recipient account does not exist
+  requirePublicRecipientAccount: boolean // When true, refunds BRIDGE_OUT txs whose Liberdus recipient account does not exist or is private
 }
 
 
@@ -124,8 +124,8 @@ function validateLiberdusBridgeGuards(chainConfigs: ChainConfigs): void {
   }
   validateBridgeGuardAmount(guards.maxBridgeInAmount, 'maxBridgeInAmount')
   validateBridgeGuardAmount(guards.maxBridgeOutAmount, 'maxBridgeOutAmount')
-  if (typeof guards.enforceRecipientExists !== 'boolean') {
-    throw new Error('[config] liberdusBridgeGuards.enforceRecipientExists must be a boolean')
+  if (typeof guards.requirePublicRecipientAccount !== 'boolean') {
+    throw new Error('[config] liberdusBridgeGuards.requirePublicRecipientAccount must be a boolean')
   }
 }
 

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -32,6 +32,7 @@ export function requireSigningChainConfig(
 
 export interface LiberdusBridgeGuards {
   maxBridgeInAmount: string       // LIB amount — operator-imposed max for BRIDGE_IN txs (Liberdus → EVM); "0" disables the limit
+  minBridgeOutAmount: string      // LIB amount — operator-imposed min for BRIDGE_OUT txs (EVM → Liberdus); "0" disables the limit
   maxBridgeOutAmount: string      // LIB amount — operator-imposed max for BRIDGE_OUT txs (EVM → Liberdus); "0" disables the limit
   requirePublicRecipientAccount: boolean // When true, refunds BRIDGE_OUT txs whose Liberdus recipient account does not exist or is private
 }
@@ -123,6 +124,7 @@ function validateLiberdusBridgeGuards(chainConfigs: ChainConfigs): void {
     throw new Error('[config] liberdusBridgeGuards is required')
   }
   validateBridgeGuardAmount(guards.maxBridgeInAmount, 'maxBridgeInAmount')
+  validateBridgeGuardAmount(guards.minBridgeOutAmount, 'minBridgeOutAmount')
   validateBridgeGuardAmount(guards.maxBridgeOutAmount, 'maxBridgeOutAmount')
   if (typeof guards.requirePublicRecipientAccount !== 'boolean') {
     throw new Error('[config] liberdusBridgeGuards.requirePublicRecipientAccount must be a boolean')


### PR DESCRIPTION
Require public Liberdus bridge recipients
- Rename the bridge-out recipient guard to requirePublicRecipientAccount.
- Revert BRIDGE_OUT when the Liberdus recipient account does not exist or is private.
- Update local chain configs to use the renamed guard.

Add minimum bridge-out guard
- Add minBridgeOutAmount to Liberdus bridge guard config.
- Revert BRIDGE_OUT back to the EVM chain when the amount is below the configured minimum.
- Keep the default minimum disabled with "0" in local chain configs.

PR for https://github.com/Liberdus/tss-signer/issues/60