### PR TITLE
Add remote software update admin support

### DIFF
--- a/OBSERVER_ADMIN.md
+++ b/OBSERVER_ADMIN.md
@@ -1,6 +1,6 @@
 # Observer Admin Operations
 
-The observer exposes admin-only tooling for collecting logs and restarting PM2 processes across observer machines.
+The observer exposes admin-only tooling for collecting logs, restarting PM2 processes, and temporarily updating software across observer machines.
 
 ## Access Rules
 
@@ -64,7 +64,7 @@ npm run operator-admin
 
 The CLI prompts for:
 
-- action: `collect-logs` or `restart`
+- action: `collect-logs`, `restart`, or `update-software`
 - target: `all` or one observer URL from `observer-list.json`
 - PM2 process name for restart: `observer` or `tss-party`
 
@@ -81,6 +81,27 @@ npm run operator-admin -- --action restart --target http://203.0.113.3:8103 --na
 ```
 
 The explicit target must match a normalized URL in `observer-list.json`.
+
+Software update example:
+
+```bash
+npm run operator-admin -- --action update-software --target all --yes
+```
+
+This calls `POST /admin/software/update` on the selected observers. The endpoint runs only this fixed sequence from the project root:
+
+```text
+git status --porcelain --untracked-files=no
+git rev-parse HEAD
+git fetch origin main
+git merge --ff-only origin/main
+git rev-parse HEAD
+npm run compile
+```
+
+The endpoint can be enabled or disabled with `SOFTWARE_UPDATE_ENABLED` at the top of `observer/admin.ts`. Keep it disabled in production unless a controlled maintenance update is needed. The current default update target is `origin/main`, configured there with `SOFTWARE_UPDATE_REMOTE` and `SOFTWARE_UPDATE_BRANCH`.
+
+If tracked files are modified or staged, the update is rejected before fetching or merging. Untracked files are ignored by this preflight. The update endpoint does not run `npm install` and does not restart PM2; run the restart action separately after a successful update.
 
 ## Collected Logs Output
 
@@ -105,10 +126,21 @@ admin-results/restart-YYYY-MM-DD-HH-mm-ss.json
 
 The manifest records requested target, requested name, resolved process name, status, duration, and error if any. Restart status `scheduled` means the target endpoint accepted the restart request; it does not mean PM2 has already completed the restart.
 
+## Software Update Output
+
+Output:
+
+```text
+admin-results/update-YYYY-MM-DD-HH-mm-ss.json
+```
+
+The manifest records each target URL, status, before/after commit, whether code changed, compile result, duration, and capped output snippets.
+
 ## Timeouts And Logs
 
 - Local archive creation timeout: 5 minutes.
 - CLI log download timeout: 5 minutes.
 - PM2 restart command timeout: 10 seconds.
+- Software update command timeout: 5 minutes per fixed command.
 - Admin endpoint attempts are logged with requester IP, normalized IP, allow/deny result, route, and outcome.
 - Log values are sanitized to avoid control-character log injection.

--- a/observer/admin.test.ts
+++ b/observer/admin.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  capAdminOutput,
   formatAdminTimestamp,
   getArchiveFilenameForObserverUrl,
   isAdminRequesterAllowed,
@@ -7,7 +8,11 @@ import {
   normalizeRemoteAddress,
   parseObserverUrlInfos,
   resolvePm2ProcessNameFromSet,
+  runSoftwareUpdate,
   sanitizeArchiveFilenamePart,
+  SOFTWARE_UPDATE_BRANCH,
+  SOFTWARE_UPDATE_REMOTE,
+  SOFTWARE_UPDATE_COMMANDS,
 } from "./admin";
 
 function testNormalizeRemoteAddress(): void {
@@ -62,14 +67,175 @@ function testFilenameHelpers(): void {
   assert.equal(getArchiveFilenameForObserverUrl("http://[2001:db8::1]:8103"), "2001_db8__1-8103.tar.gz");
 }
 
-function main(): void {
+async function testSoftwareUpdateDirtyWorktree(): Promise<void> {
+  const calls: string[] = [];
+  const result = await runSoftwareUpdate("/repo", async (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    return { code: 0, stdout: " M observer/admin.ts\n", stderr: "" };
+  });
+
+  assert.equal(result.Ok, undefined);
+  assert.equal(result.Err, "Worktree is dirty; software update aborted");
+  assert.equal(result.compileOk, false);
+  assert.deepEqual(calls, ["git status --porcelain --untracked-files=no"]);
+}
+
+async function testSoftwareUpdateStatusFailure(): Promise<void> {
+  const result = await runSoftwareUpdate("/repo", async () => ({
+    code: 128,
+    stdout: "",
+    stderr: "not a git repository\n",
+  }));
+
+  assert.equal(result.Ok, undefined);
+  assert.equal(result.Err, "git status failed with code 128");
+  assert.equal(result.compileOk, false);
+  assert.match(result.stderr, /not a git repository/);
+}
+
+async function testSoftwareUpdateCommandSequenceNoop(): Promise<void> {
+  const calls: string[] = [];
+  const responses = [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "fetch ok\n", stderr: "" },
+    { code: 0, stdout: "Already up to date.\n", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "compile ok\n", stderr: "" },
+  ];
+
+  const result = await runSoftwareUpdate("/repo", async (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    return responses.shift()!;
+  });
+
+  assert.equal(result.Ok, "software_update_completed");
+  assert.equal(result.beforeCommit, "abc123");
+  assert.equal(result.afterCommit, "abc123");
+  assert.equal(result.updated, false);
+  assert.equal(result.compileOk, true);
+  assert.deepEqual(calls, SOFTWARE_UPDATE_COMMANDS.map((entry) => `${entry.command} ${entry.args.join(" ")}`));
+}
+
+async function testSoftwareUpdateAllowsUntrackedFiles(): Promise<void> {
+  const calls: string[] = [];
+  const responses = [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "fetch ok\n", stderr: "" },
+    { code: 0, stdout: "Already up to date.\n", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "compile ok\n", stderr: "" },
+  ];
+
+  const result = await runSoftwareUpdate("/repo", async (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    return responses.shift()!;
+  });
+
+  assert.equal(calls[0], "git status --porcelain --untracked-files=no");
+  assert.equal(result.Ok, "software_update_completed");
+}
+
+async function testSoftwareUpdateFetchFailure(): Promise<void> {
+  const calls: string[] = [];
+  const responses = [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 1, stdout: "", stderr: "fetch failed\n" },
+  ];
+
+  const result = await runSoftwareUpdate("/repo", async (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    return responses.shift()!;
+  });
+
+  assert.equal(result.Ok, undefined);
+  assert.equal(result.Err, `git fetch ${SOFTWARE_UPDATE_REMOTE} ${SOFTWARE_UPDATE_BRANCH} failed with code 1`);
+  assert.equal(result.beforeCommit, "abc123");
+  assert.equal(result.afterCommit, undefined);
+  assert.equal(result.updated, false);
+  assert.equal(result.compileOk, false);
+  assert.match(result.stderr, /fetch failed/);
+  assert.deepEqual(calls, [
+    "git status --porcelain --untracked-files=no",
+    "git rev-parse HEAD",
+    `git fetch ${SOFTWARE_UPDATE_REMOTE} ${SOFTWARE_UPDATE_BRANCH}`,
+  ]);
+}
+
+async function testSoftwareUpdateMergeThrowsUnknownUpdated(): Promise<void> {
+  const calls: string[] = [];
+  const responses = [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "fetch ok\n", stderr: "" },
+  ];
+
+  const result = await runSoftwareUpdate("/repo", async (command, args) => {
+    calls.push(`${command} ${args.join(" ")}`);
+    if (command === "git" && args.join(" ") === `merge --ff-only ${SOFTWARE_UPDATE_REMOTE}/${SOFTWARE_UPDATE_BRANCH}`) {
+      throw new Error("merge process failed");
+    }
+    return responses.shift()!;
+  });
+
+  assert.equal(result.Ok, undefined);
+  assert.equal(result.Err, "merge process failed");
+  assert.equal(result.beforeCommit, "abc123");
+  assert.equal(result.afterCommit, undefined);
+  assert.equal(result.updated, undefined);
+  assert.equal(result.compileOk, false);
+  assert.deepEqual(calls, [
+    "git status --porcelain --untracked-files=no",
+    "git rev-parse HEAD",
+    `git fetch ${SOFTWARE_UPDATE_REMOTE} ${SOFTWARE_UPDATE_BRANCH}`,
+    `git merge --ff-only ${SOFTWARE_UPDATE_REMOTE}/${SOFTWARE_UPDATE_BRANCH}`,
+  ]);
+}
+
+async function testSoftwareUpdateChangedAndCompileFailed(): Promise<void> {
+  const responses = [
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "abc123\n", stderr: "" },
+    { code: 0, stdout: "fetch ok\n", stderr: "" },
+    { code: 0, stdout: "Fast-forward\n", stderr: "" },
+    { code: 0, stdout: "def456\n", stderr: "" },
+    { code: 1, stdout: "", stderr: "compile failed\n" },
+  ];
+
+  const result = await runSoftwareUpdate("/repo", async () => responses.shift()!);
+  assert.equal(result.Ok, undefined);
+  assert.equal(result.Err, "npm run compile failed with code 1");
+  assert.equal(result.beforeCommit, "abc123");
+  assert.equal(result.afterCommit, "def456");
+  assert.equal(result.updated, true);
+  assert.equal(result.compileOk, false);
+}
+
+function testSoftwareUpdateOutputCapping(): void {
+  assert.equal(capAdminOutput("abcdef", 3), "abc\n...[truncated 3 chars]");
+}
+
+async function main(): Promise<void> {
   testNormalizeRemoteAddress();
   testAdminAllowlistIpLiterals();
   testAdminAllowlistLocalhostMode();
   testProcessNameValidation();
   testPm2NameResolutionFromSet();
   testFilenameHelpers();
+  await testSoftwareUpdateDirtyWorktree();
+  await testSoftwareUpdateStatusFailure();
+  await testSoftwareUpdateCommandSequenceNoop();
+  await testSoftwareUpdateAllowsUntrackedFiles();
+  await testSoftwareUpdateFetchFailure();
+  await testSoftwareUpdateMergeThrowsUnknownUpdated();
+  await testSoftwareUpdateChangedAndCompileFailed();
+  testSoftwareUpdateOutputCapping();
   console.log("observer admin tests passed");
 }
 
-main();
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/observer/admin.ts
+++ b/observer/admin.ts
@@ -13,6 +13,22 @@ const RESTART_TIMEOUT_MS = 10 * 1000; // PM2 command timeout.
 const RESTART_DELAY_MS = 1000; // Delay before invoking PM2 restart.
 const PROCESS_NAME_PATTERN = /^(observer|tss-party)$/; // Restart only this machine's observer/TSS pair.
 
+// Software update admin endpoint. Keep this block easy to remove later.
+// Keep disabled in production unless a controlled maintenance update is needed.
+export const SOFTWARE_UPDATE_ENABLED = true;
+const SOFTWARE_UPDATE_TIMEOUT_MS = 5 * 60 * 1000;
+const SOFTWARE_UPDATE_OUTPUT_LIMIT = 20_000;
+export const SOFTWARE_UPDATE_REMOTE = "origin";
+export const SOFTWARE_UPDATE_BRANCH = "main";
+export const SOFTWARE_UPDATE_COMMANDS = [
+  { command: "git", args: ["status", "--porcelain", "--untracked-files=no"], label: "git status --porcelain --untracked-files=no" },
+  { command: "git", args: ["rev-parse", "HEAD"], label: "git rev-parse HEAD before" },
+  { command: "git", args: ["fetch", SOFTWARE_UPDATE_REMOTE, SOFTWARE_UPDATE_BRANCH], label: `git fetch ${SOFTWARE_UPDATE_REMOTE} ${SOFTWARE_UPDATE_BRANCH}` },
+  { command: "git", args: ["merge", "--ff-only", `${SOFTWARE_UPDATE_REMOTE}/${SOFTWARE_UPDATE_BRANCH}`], label: `git merge --ff-only ${SOFTWARE_UPDATE_REMOTE}/${SOFTWARE_UPDATE_BRANCH}` },
+  { command: "git", args: ["rev-parse", "HEAD"], label: "git rev-parse HEAD after" },
+  { command: "npm", args: ["run", "compile"], label: "npm run compile" },
+] as const;
+
 export interface ObserverUrlInfo {
   url: string;
   hostname: string;
@@ -29,6 +45,24 @@ interface AllowlistDecision {
 
 interface CommandResult {
   code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type SoftwareUpdateCommandRunner = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; timeoutMs?: number },
+) => Promise<CommandResult>;
+
+export interface SoftwareUpdateResult {
+  Ok?: "software_update_completed";
+  Err?: string;
+  beforeCommit?: string;
+  afterCommit?: string;
+  updated?: boolean;
+  compileOk: boolean;
+  durationMs: number;
   stdout: string;
   stderr: string;
 }
@@ -93,6 +127,11 @@ export function sanitizeArchiveFilenamePart(value: string): string {
 
 function sanitizeLogValue(value: unknown): string {
   return `${value ?? ""}`.replace(/[\r\n\t\x00-\x1F\x7F]/g, " ").slice(0, 2000);
+}
+
+export function capAdminOutput(value: string, limit = SOFTWARE_UPDATE_OUTPUT_LIMIT): string {
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit)}\n...[truncated ${value.length - limit} chars]`;
 }
 
 export function formatAdminTimestamp(date = new Date()): string {
@@ -354,6 +393,142 @@ function streamLogsArchive(res: Response, projectRoot: string, filename: string)
   });
 }
 
+
+// ---------------------------------------------------------------------------
+// Software update admin endpoint. Keep this section easy to remove later.
+// ---------------------------------------------------------------------------
+
+function appendCommandOutput(
+  output: { stdout: string; stderr: string },
+  label: string,
+  result: CommandResult,
+): void {
+  if (result.stdout) output.stdout += `\n[${label} stdout]\n${result.stdout}`;
+  if (result.stderr) output.stderr += `\n[${label} stderr]\n${result.stderr}`;
+}
+
+function buildSoftwareUpdateResult(
+  startedAt: number,
+  output: { stdout: string; stderr: string },
+  fields: Partial<SoftwareUpdateResult>,
+): SoftwareUpdateResult {
+  return {
+    compileOk: false,
+    durationMs: Date.now() - startedAt,
+    stdout: capAdminOutput(output.stdout.trim()),
+    stderr: capAdminOutput(output.stderr.trim()),
+    ...fields,
+  };
+}
+
+async function runUpdateCommand(
+  runner: SoftwareUpdateCommandRunner,
+  projectRoot: string,
+  commandSpec: typeof SOFTWARE_UPDATE_COMMANDS[number],
+): Promise<CommandResult> {
+  return runner(commandSpec.command, [...commandSpec.args], {
+    cwd: projectRoot,
+    timeoutMs: SOFTWARE_UPDATE_TIMEOUT_MS,
+  });
+}
+
+export async function runSoftwareUpdate(
+  projectRoot: string,
+  runner: SoftwareUpdateCommandRunner = runCommand,
+): Promise<SoftwareUpdateResult> {
+  const [statusCmd, beforeCmd, fetchCmd, mergeCmd, afterCmd, compileCmd] = SOFTWARE_UPDATE_COMMANDS;
+  const startedAt = Date.now();
+  const output = { stdout: "", stderr: "" };
+  let beforeCommit: string | undefined;
+  let afterCommit: string | undefined;
+
+  try {
+    const status = await runUpdateCommand(runner, projectRoot, statusCmd);
+    appendCommandOutput(output, statusCmd.label, status);
+    if (status.code !== 0) {
+      return buildSoftwareUpdateResult(startedAt, output, {
+        Err: `git status failed with code ${status.code}`,
+        beforeCommit,
+        afterCommit,
+        updated: false,
+      });
+    }
+    if (status.stdout.trim()) {
+      return buildSoftwareUpdateResult(startedAt, output, {
+        Err: "Worktree is dirty; software update aborted",
+        beforeCommit,
+        afterCommit,
+        updated: false,
+      });
+    }
+
+    const before = await runUpdateCommand(runner, projectRoot, beforeCmd);
+    appendCommandOutput(output, beforeCmd.label, before);
+    if (before.code !== 0) {
+      return buildSoftwareUpdateResult(startedAt, output, {
+        Err: `git rev-parse HEAD failed with code ${before.code}`,
+        beforeCommit,
+        afterCommit,
+        updated: false,
+      });
+    }
+    beforeCommit = before.stdout.trim();
+
+    for (const commandSpec of [fetchCmd, mergeCmd]) {
+      const result = await runUpdateCommand(runner, projectRoot, commandSpec);
+      appendCommandOutput(output, commandSpec.label, result);
+      if (result.code !== 0) {
+        return buildSoftwareUpdateResult(startedAt, output, {
+          Err: `${commandSpec.label} failed with code ${result.code}`,
+          beforeCommit,
+          afterCommit,
+          updated: false,
+        });
+      }
+    }
+
+    const after = await runUpdateCommand(runner, projectRoot, afterCmd);
+    appendCommandOutput(output, afterCmd.label, after);
+    if (after.code !== 0) {
+      return buildSoftwareUpdateResult(startedAt, output, {
+        Err: `git rev-parse HEAD failed with code ${after.code}`,
+        beforeCommit,
+        afterCommit,
+        updated: false,
+      });
+    }
+    afterCommit = after.stdout.trim();
+
+    const compile = await runUpdateCommand(runner, projectRoot, compileCmd);
+    appendCommandOutput(output, compileCmd.label, compile);
+    if (compile.code !== 0) {
+      return buildSoftwareUpdateResult(startedAt, output, {
+        Err: `npm run compile failed with code ${compile.code}`,
+        beforeCommit,
+        afterCommit,
+        updated: beforeCommit !== afterCommit,
+        compileOk: false,
+      });
+    }
+
+    return buildSoftwareUpdateResult(startedAt, output, {
+      Ok: "software_update_completed",
+      beforeCommit,
+      afterCommit,
+      updated: beforeCommit !== afterCommit,
+      compileOk: true,
+    });
+  } catch (error) {
+    return buildSoftwareUpdateResult(startedAt, output, {
+      Err: error instanceof Error ? error.message : String(error),
+      beforeCommit,
+      afterCommit,
+      updated: beforeCommit !== undefined && afterCommit !== undefined ? beforeCommit !== afterCommit : undefined,
+      compileOk: false,
+    });
+  }
+}
+
 export function createAdminRouter(getAdminContext: AdminContextProvider): Router {
   const router = express.Router();
   // Keep allowlist/audit before JSON parsing.
@@ -428,6 +603,28 @@ export function createAdminRouter(getAdminContext: AdminContextProvider): Router
       console.error(`${ADMIN_LOG_PREFIX} restart rejected requested=${sanitizeLogValue(requestedName)}: ${sanitizeLogValue(message)}`);
       res.status(500).json({ Err: message });
     }
+  });
+
+  // Software update admin endpoint. Keep restart as a separate operator action.
+  router.post("/software/update", async (_req, res) => {
+    if (!SOFTWARE_UPDATE_ENABLED) {
+      console.warn(`${ADMIN_LOG_PREFIX} software update rejected: endpoint disabled`);
+      res.status(403).json({ Err: "Software update admin endpoint disabled" });
+      return;
+    }
+
+    const adminContext = res.locals.adminContext as AdminContext;
+    const decision = res.locals.adminAllowlistDecision as AllowlistDecision | undefined;
+    console.log(
+      `${ADMIN_LOG_PREFIX} software update started requester=${sanitizeLogValue(decision?.normalizedRemoteAddress ?? "unknown")}`,
+    );
+
+    const result = await runSoftwareUpdate(adminContext.projectRoot);
+    const ok = result.Ok === "software_update_completed";
+    console.log(
+      `${ADMIN_LOG_PREFIX} software update ${ok ? "completed" : "failed"} requester=${sanitizeLogValue(decision?.normalizedRemoteAddress ?? "unknown")} before=${sanitizeLogValue(result.beforeCommit ?? "unknown")} after=${sanitizeLogValue(result.afterCommit ?? "unknown")} updated=${result.updated === true} compileOk=${result.compileOk} durationMs=${result.durationMs}`,
+    );
+    res.status(ok ? 200 : 500).json(result);
   });
 
   return router;

--- a/scripts/operator-admin.test.ts
+++ b/scripts/operator-admin.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import {
+  buildSoftwareUpdateManifest,
   bytesToKb,
   formatHttpError,
   formatResultSummary,
@@ -33,6 +34,11 @@ function testParseArgs(): void {
     yes: true,
   })
   assertThrowsMessage(() => parseArgs(['--action', 'stop']), /Invalid action/)
+  assert.deepStrictEqual(parseArgs(['--action', 'update-software', '--target', 'all', '--yes']), {
+    action: 'update-software',
+    target: 'all',
+    yes: true,
+  })
   assert.throws(() => parseArgs(['--bad']), UsageError)
   assertThrowsMessage(
     () => validateOptions({action: 'collect-logs', name: 'tss-party'}),
@@ -43,6 +49,7 @@ function testParseArgs(): void {
     /--name can only be used/,
   )
   assert.doesNotThrow(() => validateOptions({action: 'restart', name: 'tss-party'}))
+  assert.doesNotThrow(() => validateOptions({action: 'update-software'}))
 }
 
 function testTargetSelection(): void {
@@ -86,10 +93,46 @@ function testTimestampsAndSummary(): void {
   )
 }
 
+function testSoftwareUpdateManifest(): void {
+  assert.deepStrictEqual(
+    buildSoftwareUpdateManifest([
+      {
+        url: 'http://203.0.113.1:8101',
+        status: 'ok',
+        beforeCommit: 'abc123',
+        afterCommit: 'def456',
+        updated: true,
+        compileOk: true,
+        durationMs: 1500,
+        stdout: 'ok',
+        stderr: '',
+      },
+    ], '2026-05-14T10:00:00.000Z'),
+    {
+      action: 'update-software',
+      createdAt: '2026-05-14T10:00:00.000Z',
+      results: [
+        {
+          url: 'http://203.0.113.1:8101',
+          status: 'ok',
+          beforeCommit: 'abc123',
+          afterCommit: 'def456',
+          updated: true,
+          compileOk: true,
+          durationMs: 1500,
+          stdout: 'ok',
+          stderr: '',
+        },
+      ],
+    },
+  )
+}
+
 testParseArgs()
 testTargetSelection()
 testRestartNameValidation()
 testArchiveFilenameGeneration()
 testTimestampsAndSummary()
+testSoftwareUpdateManifest()
 
 console.log('operator-admin tests passed')

--- a/scripts/operator-admin.ts
+++ b/scripts/operator-admin.ts
@@ -8,7 +8,7 @@ import {formatAdminTimestamp, getArchiveFilenameForObserverUrl, isValidAdminProc
 import {loadObserverUrlsFromRoot} from '../shared/utils/observerPeers'
 import {resolveProjectRoot} from '../shared/utils/paths'
 
-type AdminAction = 'collect-logs' | 'restart'
+type AdminAction = 'collect-logs' | 'restart' | 'update-software'
 type ResultStatus = 'ok' | 'scheduled' | 'failed'
 
 type Options = {
@@ -37,8 +37,23 @@ type RestartResult = {
   error?: string
 }
 
+type SoftwareUpdateCliResult = {
+  url: string
+  status: ResultStatus
+  beforeCommit?: string
+  afterCommit?: string
+  updated?: boolean
+  compileOk?: boolean
+  durationMs: number
+  error?: string
+  stdout?: string
+  stderr?: string
+}
+
 const LOG_FETCH_TIMEOUT_MS = 5 * 60 * 1000
 const RESTART_TIMEOUT_MS = 10 * 1000
+// Covers the server-side fixed update sequence without leaving ordinary failures hanging too long.
+const SOFTWARE_UPDATE_TIMEOUT_MS = 15 * 60 * 1000
 
 export class UsageError extends Error {}
 
@@ -47,7 +62,7 @@ function usage(exitCode = 1): never {
     'Usage: node dist/scripts/operator-admin.js [options]',
     '',
     'Options:',
-    '  --action collect-logs|restart',
+    '  --action collect-logs|restart|update-software',
     '  --target all|<observer-url>',
     '  --name observer|tss-party',
     '  --yes',
@@ -67,7 +82,7 @@ export function parseArgs(argv: string[]): Options {
 
     switch (arg) {
       case '--action':
-        if (value !== 'collect-logs' && value !== 'restart') {
+        if (value !== 'collect-logs' && value !== 'restart' && value !== 'update-software') {
           throw new UsageError(`Invalid action: ${value}`)
         }
         options.action = value
@@ -178,7 +193,7 @@ async function readStreamBody(stream: any, maxBytes = 4096): Promise<string> {
 
 function selectAction(options: Options): AdminAction {
   if (options.action) return options.action
-  const choices: AdminAction[] = ['collect-logs', 'restart']
+  const choices: AdminAction[] = ['collect-logs', 'restart', 'update-software']
   console.log('Operator admin actions:')
   const selected = readlineSync.keyInSelect(choices, 'Select admin action:', {cancel: false})
   return choices[selected]
@@ -313,6 +328,73 @@ async function restartTargets(projectRoot: string, targets: string[], requestedN
   console.log(formatResultSummary(results))
 }
 
+// Software update action. Keep separate from log/restart helpers.
+async function postSoftwareUpdate(observerUrl: string): Promise<{
+  ok: boolean
+  beforeCommit?: string
+  afterCommit?: string
+  updated?: boolean
+  compileOk?: boolean
+  error?: string
+  stdout?: string
+  stderr?: string
+}> {
+  const response = await axios.post(
+    `${observerUrl}/admin/software/update`,
+    undefined,
+    {
+      timeout: SOFTWARE_UPDATE_TIMEOUT_MS,
+      maxRedirects: 0,
+      validateStatus: () => true,
+    },
+  )
+  const body = response.data && typeof response.data === 'object' ? response.data : {}
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    beforeCommit: body.beforeCommit,
+    afterCommit: body.afterCommit,
+    updated: body.updated,
+    compileOk: body.compileOk,
+    error: response.status >= 200 && response.status < 300 ? undefined : body.Err ?? formatHttpError(response.status, response.statusText, response.data),
+    stdout: body.stdout,
+    stderr: body.stderr,
+  }
+}
+
+export function buildSoftwareUpdateManifest(results: SoftwareUpdateCliResult[], createdAt = new Date().toISOString()): object {
+  return {
+    action: 'update-software',
+    createdAt,
+    results,
+  }
+}
+
+async function updateSoftwareTargets(projectRoot: string, targets: string[]): Promise<void> {
+  const outputDir = path.join(projectRoot, 'admin-results')
+  fs.mkdirSync(outputDir, {recursive: true})
+
+  const results = await Promise.all(targets.map(async (url): Promise<SoftwareUpdateCliResult> => {
+    const startedAt = Date.now()
+    try {
+      const update = await postSoftwareUpdate(url)
+      const {ok, ...fields} = update
+      return {url, status: ok ? 'ok' : 'failed', durationMs: Date.now() - startedAt, ...fields}
+    } catch (error) {
+      return {
+        url,
+        status: 'failed',
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }))
+
+  const manifestPath = path.join(outputDir, `update-${formatAdminTimestamp()}.json`)
+  fs.writeFileSync(manifestPath, `${JSON.stringify(buildSoftwareUpdateManifest(results), null, 2)}\n`)
+  console.log(`manifest=${manifestPath}`)
+  console.log(formatResultSummary(results))
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2))
   if (options.help) usage(0)
@@ -338,8 +420,10 @@ async function main(): Promise<void> {
 
   if (action === 'collect-logs') {
     await collectLogs(projectRoot, targets)
-  } else {
+  } else if (action === 'restart') {
     await restartTargets(projectRoot, targets, name as string)
+  } else {
+    await updateSoftwareTargets(projectRoot, targets)
   }
 }
 


### PR DESCRIPTION
## Summary
Adds a controlled admin software update path for observer machines, orchestrated through operator-admin and protected by the existing admin IP allowlist.

Fixes for https://github.com/Liberdus/tss-signer/issues/67

## Changes
- Add POST /admin/software/update for a fixed git fetch + ff-only merge + compile flow
- Add SOFTWARE_UPDATE_ENABLED so the endpoint can be disabled for production safety
- Configure update remote/branch at the top of observer/admin.ts, defaulting to origin/main
- Reject modified or staged tracked files before updating; ignore untracked files
- Keep software update separate from PM2 restart
- Add operator-admin update-software action and update result manifests
- Document usage, security note, and result output in OBSERVER_ADMIN.md
- Add tests for command sequence, dirty worktree handling, update failures, compile failures, output capping, and CLI manifest formatting

## Security Notes
- No request-controlled branch, remote, or shell commands
- No npm install/npm ci
- Existing observer source-IP allowlist remains the authorization model
- Keep SOFTWARE_UPDATE_ENABLED disabled in production unless controlled maintenance is needed

## Validation
- npm run compile
- node dist/observer/admin.test.js
- node dist/scripts/operator-admin.test.js
