### PR TITLE
Log TSS binary output on signing timeout

### DIFF
--- a/tss-tools/lib/bnbTss.ts
+++ b/tss-tools/lib/bnbTss.ts
@@ -421,6 +421,13 @@ function runWithLiveLogs(command: string, args: any[], options: ExecOptions = {}
       settled = true;
       cleanupTimers();
       if (timedOut) {
+        if (!shouldPrintLogs) {
+          // Live logging was suppressed; dump accumulated output so timeouts can be debugged
+          const captured = [stdout, stderr].filter(Boolean).join('\n').trim();
+          if (captured) {
+            process.stderr.write(`[tss signing timeout] captured output:\n${captured}\n`);
+          }
+        }
         reject(new Error(timeoutErrorMessage));
         return;
       }


### PR DESCRIPTION
- TSS binary stdout/stderr is now dumped to stderr when a signing timeout occurs
- Output is only dumped when live logging was suppressed (PRINT_TSS_SIGN_LOGS=false), avoiding duplication when live logging is enabled
- Successful signings remain silent as before

Fixes for issue https://github.com/Liberdus/tss-signer/pull/71