### PR TITLE
Refactor observer peer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Native helper walkthroughs and command examples live in [`tss-tools/guide.md`](t
 
 ### 4. Configure chains and params
 
-- **`params.json`** — TSS parameters. Default: `{"parties": 5, "threshold": 3}`
+- **`params.json`** — TSS keygen/regroup parameters. Default: `{"parties": 5, "threshold": 3}`. Keygen/regroup store these values in the keystore. Signing uses the keystore values, not `params.json`.
 - **`chain-config.json`** — RPC endpoints, contract addresses, gas config per chain.
-- **`observer-list.json`** — observer peer URLs as a plain JSON array; copy the shape from `observer-list.json.example` and replace the placeholder IPs with real public observer IPs. If you use DNS names, set `TSS_SELF_OBSERVER_URL` on each party so it can identify its own observer.
+- **`observer-list.json`** — observer peer URLs as a JSON array. When configured, the app uses this list to choose observer peers and determine the observer count. Copy the shape from `observer-list.json.example` and replace the placeholder IPs with real public observer IPs. If you use DNS names, set `TSS_SELF_OBSERVER_URL` on each party so it can identify its own observer.
 - **Observer setup flag** (`chain-config.json`):
   - `isRemote: false` (default): if `observer-list.json` is empty, peers default to `http://127.0.0.1:8101..`.
   - `isRemote: true`: `observer-list.json` is required and startup fails when it is missing/empty.
@@ -149,7 +149,7 @@ For manual Liberdus transaction signing/injection with `npm run inject-liberdus-
 
 ### Assisted keygen wrapper
 
-For remote multi-party keygen, `npm run tss-keygen-ceremony -- --nonce <value>` reads a local `keygen-config.json`, derives `parties`, `threshold = floor(n/2)`, the current `partyIndex`, the other parties' `peer-addrs`, and deterministic keygen channel credentials from the shared config plus `--nonce`. It prompts for the chain-specific vault password, verifies the password can unlock the initialized vault, overwrites `params.json` with the derived `{parties, threshold}`, then runs `tss-keygen` with those env vars scoped to that child process only. Use a fresh nonce for every retry, for example `--nonce 1`, then `--nonce 2`. The wrapper prints the derived UTC expiry before launching keygen. After the config is in place, `tss-verify` can omit `--chain-id` and will use `chainId` from that same file.
+For remote multi-party keygen, `npm run tss-keygen-ceremony -- --nonce <value>` reads a local `keygen-config.json`, derives `parties`, `threshold = floor(n/2)`, the current `partyIndex`, the other parties' `peer-addrs`, and deterministic keygen channel credentials from the shared config plus `--nonce`. It prompts for the chain-specific vault password, verifies the password can unlock the initialized vault, overwrites `params.json` with the derived `{parties, threshold}`, then runs `tss-keygen` with those env vars scoped to that child process only. Keygen stores those parameters in the native keystore. Use a fresh nonce for every retry, for example `--nonce 1`, then `--nonce 2`. The wrapper prints the derived UTC expiry before launching keygen. After the config is in place, `tss-verify` can omit `--chain-id` and will use `chainId` from that same file.
 
 Expected local config file:
 
@@ -246,7 +246,7 @@ Right now there are three TSS execution routes:
 | `shared/storage/transactiondb.ts` | SQLite transaction DB: types, statuses, queries |
 | `tss-tools/lib/bnbTss.ts` | Native BNB TSS runtime helper |
 | `chain-config.json` | Multi-chain RPC and contract configuration |
-| `params.json` | TSS parameters (parties, threshold) |
+| `params.json` | TSS keygen/regroup parameters (parties, threshold) |
 | `keystores/` | Native TSS vault files (created during keygen) |
 | `ecosystem.config.js` | PM2 process configuration for all 10 processes |
 
@@ -254,7 +254,7 @@ Right now there are three TSS execution routes:
 
 **Keygen:** All 5 parties participate simultaneously. Output: shared public key + individual key shares written to `keystores/bnbtss/party-N/chain-CHAINID/default/`.
 
-**Signing:** Any `threshold + 1` (≥ 4 of 5) parties suffice. The patched binary implements a configurable discovery window (`--sign_discovery_timeout`, default 5s) — once the first peer connects, signing proceeds with all parties that arrive within the window (minimum threshold).
+**Signing:** Any `threshold + 1` (≥ 4 of 5) parties suffice. The TSS binary reads the party/threshold values from the keystore, so signing does not use `params.json`. The patched binary implements a configurable discovery window (`--sign_discovery_timeout`, default 5s) — once the first peer connects, signing proceeds with all parties that arrive within the window (minimum threshold).
 
 **Regroup:** Transfers key shares to a new committee without regenerating the shared key. Requires at least `threshold + 1` old participants.
 

--- a/observer/admin.ts
+++ b/observer/admin.ts
@@ -4,7 +4,7 @@ import net from "net";
 import path from "path";
 import { spawn } from "child_process";
 import { chainConfigsRaw } from "../shared/config";
-import { deriveSelfObserverUrl, loadObserverUrlsFromRoot } from "../shared/utils/observerPeers";
+import { normalizeObserverUrl, observerPeerConfigRaw } from "../shared/utils/observerPeers";
 import { resolveProjectRoot } from "../shared/utils/paths";
 
 const ADMIN_LOG_PREFIX = "[observer/admin]";
@@ -70,8 +70,6 @@ export interface SoftwareUpdateResult {
 export interface AdminContext {
   partyIndex: number;
   projectRoot: string;
-  // Loaded once at startup.
-  observerUrls: string[];
   observerInfos: ObserverUrlInfo[];
   selfObserverUrl: string;
 }
@@ -84,10 +82,6 @@ export function normalizeRemoteAddress(address?: string | null): string {
   if (raw.startsWith("::ffff:")) return raw.slice("::ffff:".length);
   if (raw === "::1") return "::1";
   return raw;
-}
-
-function normalizeObserverUrl(rawUrl: string): string {
-  return rawUrl.trim().replace(/\/$/, "");
 }
 
 function isLocalhostAddress(address: string): boolean {
@@ -151,8 +145,10 @@ function parseObserverUrl(rawUrl: string): ObserverUrlInfo | null {
   try {
     const parsed = new URL(rawUrl);
     const hostname = parsed.hostname.replace(/^\[/, "").replace(/\]$/, "");
+    const normalizedUrl = normalizeObserverUrl(parsed.href);
+    if (!normalizedUrl) return null;
     return {
-      url: normalizeObserverUrl(parsed.href),
+      url: normalizedUrl,
       hostname,
       port: parsed.port || (parsed.protocol === "https:" ? "443" : "80"),
       isIpLiteral: net.isIP(hostname) !== 0,
@@ -184,24 +180,18 @@ export function getArchiveFilenameForObserverUrl(observerUrl: string): string {
   return `${sanitizeArchiveFilenamePart(info.hostname)}-${sanitizeArchiveFilenamePart(info.port)}.tar.gz`;
 }
 
-export async function createAdminContext(partyIndex: number, projectRoot = resolveProjectRoot()): Promise<AdminContext> {
+export function createAdminContext(partyIndex: number, selfObserverUrl: string, projectRoot = resolveProjectRoot()): AdminContext {
   const isRemote = chainConfigsRaw.isRemote === true;
-  const observerUrls = Array.from(new Set(loadObserverUrlsFromRoot(projectRoot).map(normalizeObserverUrl)));
+  const observerUrls = observerPeerConfigRaw.observerUrls;
   const observerInfos = parseObserverUrlInfos(observerUrls);
   warnIgnoredDnsHosts(observerInfos);
-  const rawSelfObserverUrl = await deriveSelfObserverUrl(partyIndex, {
-    isRemote,
-    rootDir: projectRoot,
-    observerUrls,
-  });
-  const selfObserverUrl = normalizeObserverUrl(rawSelfObserverUrl);
   if ((isRemote || observerUrls.length > 0) && !observerUrls.includes(selfObserverUrl)) {
     throw new Error(
       `${selfObserverUrl} is this observer URL but is not present in observer-list.json; update observer-list.json or TSS_SELF_OBSERVER_URL`,
     );
   }
   console.log(`${ADMIN_LOG_PREFIX} loaded admin observer context self=${sanitizeLogValue(selfObserverUrl)} observers=${observerUrls.length}`);
-  return { partyIndex, projectRoot, observerUrls, observerInfos, selfObserverUrl };
+  return { partyIndex, projectRoot, observerInfos, selfObserverUrl };
 }
 
 function computeAllowlistDecision(req: Request, adminContext: AdminContext): AllowlistDecision {

--- a/observer/index.ts
+++ b/observer/index.ts
@@ -4,7 +4,8 @@ import cors from "cors";
 import path from "path";
 import fs from "fs";
 import * as TransactionDB from "../shared/storage/transactiondb";
-import { chainConfigsRaw, getChainConfigById, isSigningChainConfig, parseBooleanOption, validateObserverSetup } from "../shared/config";
+import { chainConfigsRaw, getChainConfigById, isSigningChainConfig, parseBooleanOption } from "../shared/config";
+import { deriveSelfObserverUrl, setSelfObserverUrl } from "../shared/utils/observerPeers";
 import { isEthereumAddress, toEthereumAddress } from "../shared/utils/transformAddress";
 import { isNormalizedTxId, normalizeTxId } from "../shared/utils/transformTxId";
 import { initMonitorState, monitorState, saveMonitorState, setSyncReady, syncReady } from "./monitor/state";
@@ -62,8 +63,6 @@ console.log(`[observer] Party index: ${PARTY_INDEX}`);
 console.log(`[observer] DB path:     ${DB_PATH}`);
 console.log(`[observer] State path:  ${STATE_PATH}`);
 console.log(`[observer] HTTP port:   ${PORT}`);
-
-validateObserverSetup(chainConfigsRaw);
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -528,7 +527,9 @@ app.post("/bridgein/liberdus/submitted", (req, res) => {
     TransactionDB.initializeTransactionsDatabase(DB_PATH);
     console.log("[observer] Database initialized");
     // Loads observer-list.json once and validates this observer's self URL.
-    adminContext = await createAdminContext(PARTY_INDEX);
+    const selfObserverUrl = await deriveSelfObserverUrl(PARTY_INDEX);
+    adminContext = createAdminContext(PARTY_INDEX, selfObserverUrl);
+    setSelfObserverUrl(selfObserverUrl);
     console.log("[observer] Admin context initialized");
 
     initMonitorState(STATE_PATH);

--- a/observer/monitor/liberdus.ts
+++ b/observer/monitor/liberdus.ts
@@ -1,8 +1,8 @@
 import { ethers } from "ethers";
 import axios from "axios";
 import * as TransactionDB from "../../shared/storage/transactiondb";
-import { chainConfigsRaw, getChainConfigById, isSigningChainConfig, paramsConfigRaw, parseBooleanOption } from "../../shared/config";
-import { getCachedPeerObserverUrls } from "../../shared/utils/observerPeers";
+import { chainConfigsRaw, getChainConfigById, isSigningChainConfig, parseBooleanOption } from "../../shared/config";
+import { getPeerObserverUrls } from "../../shared/utils/observerPeers";
 import { toEthereumAddress, toShardusAddress } from "../../shared/utils/transformAddress";
 import { normalizeTxId } from "../../shared/utils/transformTxId";
 import { observerChainRpc } from "../chainRpc";
@@ -235,7 +235,7 @@ function parseLiberdusBridgeTx(
 }
 
 async function fetchPeerTransactionByReceiptId(receiptId: string): Promise<TransactionDB.Transaction | null> {
-  const peerUrls = getCachedPeerObserverUrls(paramsConfigRaw.parties);
+  const peerUrls = getPeerObserverUrls();
   for (const baseUrl of peerUrls) {
     try {
       const response = await axios.get(`${baseUrl}/transaction`, {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "tss-describe": "npm run compile && node dist/tss-tools/describe.js",
     "tss-verify": "npm run compile && node dist/tss-tools/verify.js",
     "tss-sign-ethereum-tx": "npm run compile && node dist/tss-tools/sign-ethereum-tx.js",
-    "test:tss-tools": "node dist/tss-tools/lib/committeeTopology.test.js && node dist/tss-tools/lib/channelId.test.js && node dist/tss-tools/lib/keygenCeremony.test.js && node dist/scripts/tss-connectivity-check.test.js && node dist/scripts/tss-regroup-connectivity-check.test.js && node dist/scripts/operator-admin.test.js && node dist/tss-tools/lib/regroupCeremony.test.js && node dist/tss-tools/lib/tssPartyDefaults.test.js && node dist/tss-tools/lib/bnbTss.test.js && node dist/observer/admin.test.js && bash ./tss-tools/setup-mise-go.test.sh",
+    "test:tss-tools": "node dist/tss-tools/lib/committeeTopology.test.js && node dist/tss-tools/lib/channelId.test.js && node dist/tss-tools/lib/keygenCeremony.test.js && node dist/scripts/tss-connectivity-check.test.js && node dist/scripts/tss-regroup-connectivity-check.test.js && node dist/scripts/operator-admin.test.js && node dist/shared/utils/observerPeers.test.js && node dist/tss-tools/lib/regroupCeremony.test.js && node dist/tss-tools/lib/tssPartyDefaults.test.js && node dist/tss-tools/lib/bnbTss.test.js && node dist/observer/admin.test.js && bash ./tss-tools/setup-mise-go.test.sh",
     "start-tss": "npm run compile && pm2 start ecosystem.config.js",
     "stop-tss": "pm2 stop ecosystem.config.js",
     "restart-tss": "npm run compile && pm2 restart ecosystem.config.js",

--- a/params.json
+++ b/params.json
@@ -1,1 +1,1 @@
-{"parties":8, "threshold":4}
+{"parties":5, "threshold":3}

--- a/scripts/gossip.ts
+++ b/scripts/gossip.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { chainConfigsRaw, getChainConfigById } from "../shared/config";
 import { EVMBridgeInGossipPayload } from "../shared/utils/evmBridgeInGossip";
 import { LiberdusBridgeInGossipPayload } from "../shared/utils/liberdusBridgeInGossip";
-import { getCachedPeerObserverUrls } from "../shared/utils/observerPeers";
+import { getPeerObserverUrls } from "../shared/utils/observerPeers";
 
 function getAxiosErrorMessage(error: unknown): string {
   return axios.isAxiosError(error)
@@ -70,10 +70,9 @@ function logEvmGossip(
 export async function gossipBridgeIn(
   route: GossipBridgeInRoute,
   payload: GossipBridgeInPayload,
-  peerCount: number,
   selfObserverUrl?: string,
 ): Promise<void> {
-  const peerUrls = getCachedPeerObserverUrls(peerCount, { selfObserverUrl });
+  const peerUrls = getPeerObserverUrls({ selfObserverUrl });
   if (peerUrls.length === 0) return;
 
   const isLiberdusPayload = route === "liberdus";

--- a/scripts/operator-admin.ts
+++ b/scripts/operator-admin.ts
@@ -5,7 +5,7 @@ import {pipeline} from 'stream/promises'
 import axios from 'axios'
 import readlineSync from 'readline-sync'
 import {formatAdminTimestamp, getArchiveFilenameForObserverUrl, isValidAdminProcessName} from '../observer/admin'
-import {loadObserverUrlsFromRoot} from '../shared/utils/observerPeers'
+import {observerPeerConfigRaw} from '../shared/utils/observerPeers'
 import {resolveProjectRoot} from '../shared/utils/paths'
 
 type AdminAction = 'collect-logs' | 'restart' | 'update-software'
@@ -127,8 +127,8 @@ export function normalizeObserverUrl(rawUrl: string): string {
   }
 }
 
-function loadAdminObserverUrls(projectRoot: string): string[] {
-  return Array.from(new Set(loadObserverUrlsFromRoot(projectRoot).map(normalizeObserverUrl)))
+function loadAdminObserverUrls(): string[] {
+  return observerPeerConfigRaw.observerUrls
 }
 
 export function resolveTargets(target: string, observerUrls: string[]): string[] {
@@ -401,7 +401,7 @@ async function main(): Promise<void> {
   validateOptions(options)
 
   const projectRoot = resolveProjectRoot()
-  const observerUrls = loadAdminObserverUrls(projectRoot)
+  const observerUrls = loadAdminObserverUrls()
   if (observerUrls.length === 0) {
     throw new Error('observer-list.json has no observer URLs')
   }

--- a/scripts/tss-party.ts
+++ b/scripts/tss-party.ts
@@ -15,9 +15,6 @@ import {
   getChainConfigById,
   requireSigningChainConfig,
   toNetworkChainId,
-  ParamsConfig,
-  paramsConfigRaw,
-  validateObserverSetup,
 } from '../shared/config'
 import {resolveProjectRoot} from '../shared/utils/paths'
 import {startDriftResistantScheduler} from '../shared/utils/scheduler'
@@ -144,10 +141,7 @@ const DEBUG_SIMULATE_NONCE_DRIFT = false
 
 const serverStartTime = Date.now()
 
-const params: ParamsConfig = paramsConfigRaw
 const chainConfigs: ChainConfigs = chainConfigsRaw
-
-let n = params.parties
 
 const TSS_SIGN_DISCOVERY_TIMEOUT_MS = 60 * 1000
 const TSS_SIGN_DISCOVERY_TIMEOUT = `${TSS_SIGN_DISCOVERY_TIMEOUT_MS / 1000}s`
@@ -1264,7 +1258,7 @@ async function processCoinToToken(
         receiptId: normalizeTxId(cached.txHash),
         signedTx: cached.signedTx,
         nonce: senderNonce,
-      }, n, observerUrl)
+      }, observerUrl)
       const cachedReceipt = await getChainTransactionReceipt(targetChainId, cached.txHash)
       if (cachedReceipt?.status === 1) {
         const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
@@ -1415,7 +1409,7 @@ async function processCoinToToken(
       receiptId: normalizeTxId(txHash),
       signedTx: signedTx as string,
       nonce: senderNonce,
-    }, n, observerUrl)
+    }, observerUrl)
   }
 
   let receipt: ethers.providers.TransactionReceipt | null = null
@@ -1605,7 +1599,7 @@ async function processVaultBridge(
         receiptId: normalizeTxId(cached.txHash),
         signedTx: cached.signedTx,
         nonce: senderNonce,
-      }, n, observerUrl)
+      }, observerUrl)
       const receipt = await getChainTransactionReceipt(destinationChainId, cached.txHash)
       if (receipt?.status === 1) {
         const updateResult = updateTxStatusInLocalDB(txId, TransactionStatus.COMPLETED, cached.txHash, tssSender, TransactionDB.txNonce(senderNonce))
@@ -1755,7 +1749,7 @@ async function processVaultBridge(
       receiptId: normalizeTxId(txHash),
       signedTx: signedTx as string,
       nonce: senderNonce,
-    }, n, observerUrl)
+    }, observerUrl)
   }
 
   let receipt: ethers.providers.TransactionReceipt | null = null
@@ -1963,7 +1957,7 @@ async function processTokenToCoin(
       receiptId: normalizeTxId(signedTxId),
       liberdusSignedTx: stringify(signedTx as SignedTx),
       txTimestamp: liberdusReceiptTimestamp,
-    }, n, observerUrl)
+    }, observerUrl)
   }
 
   let fetchReceiptRetry = 3
@@ -2298,10 +2292,7 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
-  validateObserverSetup(chainConfigs)
-  observerUrl = await deriveSelfObserverUrl(ourParty.idx, {
-    isRemote: chainConfigs.isRemote === true,
-  })
+  observerUrl = await deriveSelfObserverUrl(ourParty.idx)
   console.log(`[tss-party] Observer URL: ${observerUrl}`)
 
   // Initialize local DB (shared with the paired observer process)

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import {ethers} from 'ethers'
 import {resolveRepoConfigPath} from './utils/paths'
-import {loadObserverUrlsFromRoot} from './utils/observerPeers'
 
 export interface ChainConfig {
   name: string
@@ -128,21 +127,6 @@ function validateLiberdusBridgeGuards(chainConfigs: ChainConfigs): void {
   validateBridgeGuardAmount(guards.maxBridgeOutAmount, 'maxBridgeOutAmount')
   if (typeof guards.requirePublicRecipientAccount !== 'boolean') {
     throw new Error('[config] liberdusBridgeGuards.requirePublicRecipientAccount must be a boolean')
-  }
-}
-
-export function validateObserverSetup(chainConfigs: ChainConfigs): void {
-  if (typeof chainConfigs.isRemote !== 'undefined' && typeof chainConfigs.isRemote !== 'boolean') {
-    throw new Error('[config] isRemote must be a boolean when provided')
-  }
-  const isRemote = chainConfigs.isRemote === true
-  if (isRemote) {
-    const observerUrls = loadObserverUrlsFromRoot()
-    if (observerUrls.length === 0) {
-      throw new Error(
-        '[config] isRemote is true but observer-list.json is missing or empty. Configure observer-list.json for remote deployments.',
-      )
-    }
   }
 }
 

--- a/shared/utils/observerPeers.test.ts
+++ b/shared/utils/observerPeers.test.ts
@@ -71,10 +71,14 @@ function testPeerSelectionUsesConfiguredSelfUrl(): void {
   if (observerUrls.length < 2) return;
 
   setSelfObserverUrl(`${observerUrls[0]}/`);
-  assert.deepEqual(
-    getPeerObserverUrls(),
-    observerUrls.slice(1),
-  );
+  try {
+    assert.deepEqual(
+      getPeerObserverUrls(),
+      observerUrls.slice(1),
+    );
+  } finally {
+    setSelfObserverUrl('');
+  }
 }
 
 function main(): void {

--- a/shared/utils/observerPeers.test.ts
+++ b/shared/utils/observerPeers.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  buildObserverUrls,
+  getPeerObserverUrls,
+  normalizeObserverUrl,
+  observerPeerConfigRaw,
+  setSelfObserverUrl,
+} from './observerPeers';
+import { paramsConfigRaw } from '../config';
+import { resolveProjectRoot } from './paths';
+
+function readExpectedConfiguredObserverUrls(): string[] {
+  const observerListPath = path.join(resolveProjectRoot(), 'observer-list.json');
+  if (!fs.existsSync(observerListPath)) return [];
+
+  const raw = JSON.parse(fs.readFileSync(observerListPath, 'utf8')) as unknown;
+  assert.ok(Array.isArray(raw));
+  return raw
+    .map((entry) => {
+      assert.equal(typeof entry, 'string');
+      return normalizeObserverUrl(entry);
+    })
+    .filter(Boolean);
+}
+
+function testConfiguredObserverUrls(): void {
+  const expectedObserverUrls = readExpectedConfiguredObserverUrls();
+  assert.deepEqual(observerPeerConfigRaw.observerUrls, expectedObserverUrls);
+}
+
+function testObserverPartyCount(): void {
+  const expectedObserverUrls = readExpectedConfiguredObserverUrls();
+  assert.equal(
+    observerPeerConfigRaw.partyCount,
+    expectedObserverUrls.length > 0 ? expectedObserverUrls.length : paramsConfigRaw.parties,
+  );
+}
+
+function testBuildObserverUrls(): void {
+  const expectedObserverUrls = readExpectedConfiguredObserverUrls();
+  const expectedUrls = expectedObserverUrls.length > 0
+    ? expectedObserverUrls
+    : Array.from({ length: paramsConfigRaw.parties }, (_, index) => `http://127.0.0.1:${8101 + index}`);
+  assert.deepEqual(buildObserverUrls(), expectedUrls);
+}
+
+function testPeerSelectionUsesPartyIndex(): void {
+  const observerUrls = buildObserverUrls();
+  if (observerUrls.length < 2) return;
+
+  const previousPartyIndex = process.env.PARTY_INDEX;
+  process.env.PARTY_INDEX = '2';
+  try {
+    assert.deepEqual(
+      getPeerObserverUrls(),
+      observerUrls.filter((_, index) => index !== 1),
+    );
+  } finally {
+    if (previousPartyIndex == null) {
+      delete process.env.PARTY_INDEX;
+    } else {
+      process.env.PARTY_INDEX = previousPartyIndex;
+    }
+  }
+}
+
+function testPeerSelectionUsesConfiguredSelfUrl(): void {
+  const observerUrls = buildObserverUrls();
+  if (observerUrls.length < 2) return;
+
+  setSelfObserverUrl(`${observerUrls[0]}/`);
+  assert.deepEqual(
+    getPeerObserverUrls(),
+    observerUrls.slice(1),
+  );
+}
+
+function main(): void {
+  testConfiguredObserverUrls();
+  testObserverPartyCount();
+  testBuildObserverUrls();
+  testPeerSelectionUsesPartyIndex();
+  testPeerSelectionUsesConfiguredSelfUrl();
+  console.log('observer peers tests passed');
+}
+
+main();

--- a/shared/utils/observerPeers.ts
+++ b/shared/utils/observerPeers.ts
@@ -1,19 +1,23 @@
 import fs from "fs";
 import https from "https";
 import path from "path";
+import { chainConfigsRaw, paramsConfigRaw } from "../config";
 import { resolveProjectRoot } from "./paths";
-
-interface ChainConfigLike {
-  isRemote?: boolean;
-}
 
 interface PeerObserverSelectionOptions {
   selfObserverUrl?: string;
-  rootDir?: string;
 }
 
-const cachedPeerObserverUrlsByKey = new Map<string, string[]>();
+export type ObserverPeerConfig = {
+  observerUrls: string[];
+  partyCount: number;
+}
+
+
 const OBSERVER_LIST_FILE = 'observer-list.json';
+
+let configuredSelfObserverUrl: string | undefined;
+
 const PUBLIC_IP_LOOKUP_URLS = [
   "https://api.ipify.org",
   "https://ifconfig.me/ip",
@@ -31,11 +35,11 @@ function parseObserverList(raw: unknown): string[] {
     if (typeof entry !== 'string') {
       throw new Error(`[config] ${OBSERVER_LIST_FILE}[${index}] must be a string`);
     }
-    return entry.trim();
-  }).filter(Boolean);
+    return normalizeObserverUrl(entry);
+  }).filter((entry): entry is string => entry !== null);
 }
 
-export function loadObserverUrlsFromRoot(rootDir = resolveProjectRoot()): string[] {
+export function loadObserverUrlsConfig(rootDir = resolveProjectRoot()): string[] {
   const observerListPath = path.join(rootDir, OBSERVER_LIST_FILE);
   if (!fs.existsSync(observerListPath)) {
     return [];
@@ -50,46 +54,44 @@ export function loadObserverUrlsFromRoot(rootDir = resolveProjectRoot()): string
   }
 }
 
-function readRemoteFlagFromChainConfig(rootDir: string): boolean {
-  const configPath = path.join(rootDir, "chain-config.json");
-  if (!fs.existsSync(configPath)) {
-    return false;
-  }
-  try {
-    const raw = JSON.parse(fs.readFileSync(configPath, "utf8")) as ChainConfigLike;
-    return raw.isRemote === true;
-  } catch {
-    return false;
+export function buildObserverPeerConfig(observerUrls: string[], parties: number): ObserverPeerConfig {
+  return {
+    observerUrls,
+    partyCount: observerUrls.length > 0
+      ? observerUrls.length
+      : parties,
   }
 }
 
-export function buildObserverUrls(parties: number, rootDir = resolveProjectRoot()): string[] {
-  const isRemote = readRemoteFlagFromChainConfig(rootDir);
-  const observerUrls = loadObserverUrlsFromRoot(rootDir);
-  if (isRemote) {
-    if (observerUrls.length === 0) {
-      throw new Error(
-        '[observerPeers] isRemote is true but observer-list.json is missing or empty',
-      );
-    }
-    return observerUrls;
-  }
+
+export function buildObserverUrls(): string[] {
+  const { observerUrls, partyCount } = observerPeerConfigRaw;
   if (observerUrls.length > 0) {
     return observerUrls;
   }
 
-  const count = Math.max(1, parties);
-  return Array.from({ length: count }, (_, index) => localObserverUrl(index + 1));
+  return Array.from({ length: partyCount }, (_, index) => localObserverUrl(index + 1));
 }
 
-function normalizeObserverUrl(rawUrl?: string): string | null {
+function validateObserverSetup(observerUrls: string[]): void {
+  if (typeof chainConfigsRaw.isRemote !== 'undefined' && typeof chainConfigsRaw.isRemote !== 'boolean') {
+    throw new Error('[config] isRemote must be a boolean when provided');
+  }
+  if (chainConfigsRaw.isRemote === true && observerUrls.length === 0) {
+    throw new Error(
+      '[config] isRemote is true but observer-list.json is missing or empty. Configure observer-list.json for remote deployments.',
+    );
+  }
+}
+
+export function normalizeObserverUrl(rawUrl?: string): string | null {
   const candidate = `${rawUrl ?? ""}`.trim();
   if (!candidate) return null;
   try {
     const parsed = new URL(candidate);
     return parsed.href.replace(/\/$/, "");
   } catch {
-    return candidate.replace(/\/$/, "");
+    return null;
   }
 }
 
@@ -98,7 +100,7 @@ function findObserverUrlByHost(observerUrls: string[], host: string): string | n
     try {
       const parsed = new URL(observerUrl);
       if (parsed.hostname === host) {
-        return normalizeObserverUrl(observerUrl);
+        return observerUrl;
       }
     } catch {
       // Invalid observer URLs are rejected by observer-list parsing.
@@ -143,14 +145,14 @@ async function getPublicIp(timeoutMs = 2_000): Promise<string | null> {
   return null;
 }
 
-export async function deriveSelfObserverUrl(partyIdx: number, options: { isRemote?: boolean; rootDir?: string; observerUrls?: string[] } = {}): Promise<string> {
+export async function deriveSelfObserverUrl(partyIdx: number): Promise<string> {
   const configuredSelfUrl = resolveSelfObserverUrl({});
   if (configuredSelfUrl) {
     return configuredSelfUrl;
   }
 
-  if (options.isRemote === true) {
-    const observerUrls = options.observerUrls ?? loadObserverUrlsFromRoot(options.rootDir ?? resolveProjectRoot());
+  const { observerUrls } = observerPeerConfigRaw;
+  if (chainConfigsRaw.isRemote === true) {
     const publicIp = await getPublicIp();
     const matchingPublicObserverUrl = publicIp
       ? findObserverUrlByHost(observerUrls, publicIp)
@@ -166,8 +168,12 @@ export async function deriveSelfObserverUrl(partyIdx: number, options: { isRemot
 }
 
 function resolveSelfObserverUrl(options: PeerObserverSelectionOptions): string | null {
-  const configuredSelfUrl = options.selfObserverUrl ?? process.env.TSS_SELF_OBSERVER_URL;
+  const configuredSelfUrl = options.selfObserverUrl ?? configuredSelfObserverUrl ?? process.env.TSS_SELF_OBSERVER_URL;
   return normalizeObserverUrl(configuredSelfUrl);
+}
+
+export function setSelfObserverUrl(url: string): void {
+  configuredSelfObserverUrl = normalizeObserverUrl(url) ?? undefined;
 }
 
 function resolvePartyIndex(): number | null {
@@ -176,12 +182,11 @@ function resolvePartyIndex(): number | null {
   return parsedPartyIndex;
 }
 
-export function getPeerObserverUrls(parties: number, options: PeerObserverSelectionOptions = {}): string[] {
-  const rootDir = options.rootDir ?? resolveProjectRoot();
-  const urls = buildObserverUrls(parties, rootDir);
+export function getPeerObserverUrls(options: PeerObserverSelectionOptions = {}): string[] {
+  const urls = buildObserverUrls();
   const selfObserverUrl = resolveSelfObserverUrl(options);
   if (selfObserverUrl) {
-    return urls.filter((url) => normalizeObserverUrl(url) !== selfObserverUrl);
+    return urls.filter((url) => url !== selfObserverUrl);
   }
 
   const partyIndex = resolvePartyIndex();
@@ -193,24 +198,6 @@ export function getPeerObserverUrls(parties: number, options: PeerObserverSelect
   return urls;
 }
 
-export function getCachedPeerObserverUrls(parties: number, options: PeerObserverSelectionOptions = {}): string[] {
-  const rootDir = options.rootDir ?? resolveProjectRoot();
-  const selfObserverUrl = resolveSelfObserverUrl(options);
-  const partyIndex = resolvePartyIndex();
-  const identityKey = selfObserverUrl
-    ? `url:${selfObserverUrl}`
-    : `index:${partyIndex ?? "none"}`;
-
-  const cacheKey = `${parties}|${rootDir}|${identityKey}`;
-  const cached = cachedPeerObserverUrlsByKey.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-  const computed = getPeerObserverUrls(parties, { ...options, rootDir });
-  cachedPeerObserverUrlsByKey.set(cacheKey, computed);
-  return computed;
-}
-
-export function resetCachedPeerObserverUrls(): void {
-  cachedPeerObserverUrlsByKey.clear();
-}
+export const observerUrlsRaw = loadObserverUrlsConfig();
+validateObserverSetup(observerUrlsRaw);
+export const observerPeerConfigRaw = buildObserverPeerConfig(observerUrlsRaw, paramsConfigRaw.parties);

--- a/tss-tools/lib/bnbTss.ts
+++ b/tss-tools/lib/bnbTss.ts
@@ -421,6 +421,13 @@ function runWithLiveLogs(command: string, args: any[], options: ExecOptions = {}
       settled = true;
       cleanupTimers();
       if (timedOut) {
+        if (!shouldPrintLogs) {
+          // Live logging was suppressed; dump accumulated output so timeouts can be debugged
+          const captured = [stdout, stderr].filter(Boolean).join('\n').trim();
+          if (captured) {
+            process.stderr.write(`[tss signing timeout] captured output:\n${captured}\n`);
+          }
+        }
         reject(new Error(timeoutErrorMessage));
         return;
       }


### PR DESCRIPTION
- Load observer peer config eagerly in observerPeers.ts

- Prefer observer-list.json for peer counts with params.json as local fallback

- Centralize self observer URL handling for gossip and Liberdus peer lookups

- Remove observer runtime dependency on params.json party count

- Add observer peer coverage to the test suite

Fixes for issue https://github.com/Liberdus/tss-signer/issues/69 