### PR TITLE
Port native TSS to tss-lib v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ These scripts live under [`tss-tools/`](tss-tools) and are the operator-facing h
 | `tss-tools/lib/channelId.ts` | Deterministic signing `channelId` and `channelPassword` derivation helpers. |
 | `scripts/inject-liberdus-tx.ts` | Signs a Liberdus tx payload through native BNB TSS, verifies the signature, and optionally injects it into the Liberdus network. |
 | `tss-tools/patches/tss-source.patch` | The local patch applied onto the upstream `tss` source before build/use. See [`tss-tools/patches/README.md`](tss-tools/patches/README.md) for a description of every change. |
+| `tss-tools/tss_workflow_smoke.sh` | Local end-to-end native TSS smoke workflow: init, keygen, sign, regroup to 5, sign, regroup down to 3, and final sign. Run after `npm run tss-build`. |
 | `tss-tools/test-sign-rounds.sh` | Multi-scenario signing test harness. Runs configurable rounds across varying party startup delays and reports PASS/FAIL. Logs to `tss-tools/test-result.log` and `tss-tools/test-party{1..N}.log`. |
 | `tss-tools/derive-pubkey/main.go` | Small Go helper source staged into `tss/.tooling` and run inside the upstream `tss` module for `verify.ts` and post-keygen address derivation. |
 | `tss-tools/guide.md` | Step-by-step local operator guide for build, init, keygen, verify, sign, and regroup. |

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -214,7 +214,7 @@ git submodule update --init --recursive
 
 # Bootstrap vendored Go toolchain if system go is missing or wrong version
 echo -e "\n${YELLOW}Bootstrapping Go toolchain (if needed)...${NC}"
-if ! command -v go &>/dev/null || [[ "$(go version 2>/dev/null)" != *"go1.20"* ]]; then
+if ! command -v go &>/dev/null || [[ "$(go version 2>/dev/null)" != *"go1.23"* ]]; then
     ./tss-tools/setup-mise-go.sh
 fi
 

--- a/tss-tools/README.md
+++ b/tss-tools/README.md
@@ -29,6 +29,8 @@ This directory contains the `tss-signer`-owned native TSS tools for the upstream
   - Windows is not supported by this bootstrap flow.
 - `test-sign-rounds.sh`
   - Multi-scenario signing test harness. Runs configurable rounds across 34 startup-delay scenarios for a configurable committee size (default 7-party, threshold=3, min_sign=4 for thorough coverage). Reports PASS/FAIL per scenario. Logs to `test-result.log` and `test-party{1..N}.log`.
+- `tss_workflow_smoke.sh`
+  - Local end-to-end native TSS workflow smoke test. It initializes five local parties, runs 3-party keygen, signs, regroups from 3 to 5 parties, signs again, regroups down to a final 3-party committee, and signs with the final committee. It runs the native binary from `tss/.tooling/bin` so the bundled `tbnbcli` is found by the upstream keygen/regroup flow.
 - `patch-peer-addrs/`
   - Standalone Go utility that patches the `peer_addrs` and `peers` fields inside each party's encrypted `config.json` vault file. Needed when keystores were generated locally (all peers on `127.0.0.1`) and must be deployed to separate machines with real public IPs. Built by `npm run tss-build` to `tss/.tooling/bin/patch-peer-addrs`. See [Patching peer addresses](#patching-peer-addresses) below.
 - `guide.md`
@@ -57,6 +59,14 @@ User-facing party indices start at 1. The binary resolves to `tss/.tooling/bin/t
 For the remote multi-IP keygen/regroup test flow, see `keygen-regroup-ceremony.md`.
 For the broader production/operator procedure, see `../PARTY_SETUP.md`.
 For the lower-level operator workflow, see `guide.md`.
+
+For a single-machine native TSS smoke test after `npm run tss-build`, run:
+
+```bash
+./tss-tools/tss_workflow_smoke.sh
+```
+
+The smoke script uses fixed localhost ports and exits early if any required port is already in use. Logs are written under `/private/tmp/tss-workflow-smoke.*` by default.
 
 ---
 

--- a/tss-tools/build-tss.sh
+++ b/tss-tools/build-tss.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_GO_VERSION="1.20.3"
+DEFAULT_GO_VERSION="1.23.12"
 DEFAULT_BINARY_NAME="tss"
 DEFAULT_DERIVE_BINARY_NAME="tss-derive-pubkey"
 DEFAULT_TBNBCLI_NAME="tbnbcli"

--- a/tss-tools/guide.md
+++ b/tss-tools/guide.md
@@ -421,7 +421,24 @@ npm run tss-sign-ethereum-tx -- --party 1 --chain-id 97 --tx-file ethereum-tx.js
 npm run inject-liberdus-tx -- --chain-id 97 --party 1 --tx-file ./liberdus-tx.json.example --dry-run
 
 
-# 19) Sign bootstrap — flexible k-of-n signing and discovery timeout
+# 19.1) Local native workflow smoke test
+#
+# After building the native binary, this runs a same-machine end-to-end workflow:
+# - init 5 local parties
+# - keygen with parties 1,2,3
+# - sign with the initial committee
+# - regroup from 3 parties to 5 parties
+# - sign with the 5-party committee
+# - regroup down to a final 3-party committee
+# - sign with the final committee
+#
+# The script runs the native binary from tss/.tooling/bin so upstream keygen and
+# regroup can find the bundled tbnbcli in their working directory. It also checks
+# that its fixed localhost ports are free before starting.
+./tss-tools/tss_workflow_smoke.sh
+
+
+# 19.2) Sign bootstrap — flexible k-of-n signing and discovery timeout
 #
 # The patched tss binary supports flexible k-of-n signing. Once the first peer
 # connects during sign bootstrap, a discovery window opens. If all n parties

--- a/tss-tools/lib/bnbTss.ts
+++ b/tss-tools/lib/bnbTss.ts
@@ -9,7 +9,7 @@ import {resolveProjectRoot} from '../../shared/utils/paths'
 export {}
 
 export const DEFAULT_VAULT_NAME = 'default';
-const DEFAULT_GO_VERSION = '1.20.3';
+const DEFAULT_GO_VERSION = '1.23.12';
 const DEFAULT_MISE_VERSION = 'v2026.3.8';
 const DEFAULT_BINARY_NAME = 'tss';
 const DEFAULT_DERIVE_BINARY_NAME = 'tss-derive-pubkey';

--- a/tss-tools/patches/README.md
+++ b/tss-tools/patches/README.md
@@ -4,6 +4,14 @@ Local patch applied onto the upstream [bnb-chain/tss](https://github.com/bnb-cha
 
 ## Changes
 
+### `go.mod` and TSS wrapper — upgrade to `tss-lib/v3`
+
+Updates the native TSS module to Go `1.23` / toolchain `1.23.12`, imports `github.com/bnb-chain/tss-lib/v3` at `v3.0.0`, refreshes the dependency graph, uses the v3 pointer result channels for keygen/regroup save-data completion and signing completion, and replaces the old `btcd/btcec` compressed public-key serialization with local SEC 1 compressed public-key encoding.
+
+**Why:** Keeps the native TSS binary compatible with `tss-lib/v3` and Go `1.23.12`, while avoiding `btcd` dependency conflicts by handling compressed public-key serialization locally.
+
+---
+
 ### `cmd/sign.go` — read `--message` from flag instead of hard-coding `"0"`
 
 The upstream `setMessage()` always set `TssCfg.Message = "0"`. This change reads the `--message` flag value first, falling back to an interactive stdin prompt when the flag is absent.

--- a/tss-tools/patches/tss-source.patch
+++ b/tss-tools/patches/tss-source.patch
@@ -1,8 +1,66 @@
 diff --git a/client/client.go b/client/client.go
-index 35ca66f..f7d234d 100644
+index 35ca66f..7eed479 100644
 --- a/client/client.go
 +++ b/client/client.go
-@@ -271,9 +271,17 @@ func (client *TssClient) handleMessageRoutine() {
+@@ -10,11 +10,10 @@ import (
+ 	"strconv"
+ 	"time"
+ 
+-	lib "github.com/bnb-chain/tss-lib/v2/common"
+-	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+-	"github.com/bnb-chain/tss-lib/v2/ecdsa/resharing"
+-	"github.com/bnb-chain/tss-lib/v2/tss"
+-	"github.com/btcsuite/btcd/btcec"
++	lib "github.com/bnb-chain/tss-lib/v3/common"
++	"github.com/bnb-chain/tss-lib/v3/ecdsa/keygen"
++	"github.com/bnb-chain/tss-lib/v3/ecdsa/resharing"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 	"google.golang.org/protobuf/proto"
+ 
+ 	"github.com/bnb-chain/tss/common"
+@@ -56,8 +55,8 @@ type TssClient struct {
+ 	key           *keygen.LocalPartySaveData
+ 	signature     []byte
+ 
+-	saveCh chan keygen.LocalPartySaveData
+-	signCh chan lib.SignatureData
++	saveCh chan *keygen.LocalPartySaveData
++	signCh chan *lib.SignatureData
+ 	sendCh chan tss.Message
+ 
+ 	mode ClientMode
+@@ -163,8 +162,8 @@ func NewTssClient(config *common.TssConfig, mode ClientMode, mock bool) *TssClie
+ 	}
+ 	sortedIds := tss.SortPartyIDs(unsortedPartyIds)
+ 	p2pCtx := tss.NewPeerContext(sortedIds)
+-	saveCh := make(chan keygen.LocalPartySaveData)
+-	signCh := make(chan lib.SignatureData)
++	saveCh := make(chan *keygen.LocalPartySaveData)
++	signCh := make(chan *lib.SignatureData)
+ 	sendCh := make(chan tss.Message, len(sortedIds)*10*2) // max signing messages 10 times hash confirmation messages
+ 	c := TssClient{
+ 		config:       config,
+@@ -185,11 +184,15 @@ func NewTssClient(config *common.TssConfig, mode ClientMode, mock bool) *TssClie
+ 		Logger.Infof("[%s] initialized localParty: %s", config.Moniker, localParty)
+ 	} else if mode == SignMode {
+ 		key := loadSavedKeyForSign(config, sortedIds, signers)
+-		pubKey := btcec.PublicKey(ecdsa.PublicKey{tss.EC(), key.ECDSAPub.X(), key.ECDSAPub.Y()})
+-		Logger.Infof("[%s] public key: %X\n", config.Moniker, pubKey.SerializeCompressed())
+-		address, err := GetAddress(ecdsa.PublicKey{tss.EC(), key.ECDSAPub.X(), key.ECDSAPub.Y()}, config.AddressPrefix)
++		pubKey := ecdsa.PublicKey{Curve: tss.EC(), X: key.ECDSAPub.X(), Y: key.ECDSAPub.Y()}
++		pubKeyBytes, err := compressedPubKey(pubKey)
+ 		if err != nil {
+-			panic(err)
++			common.Panic(err)
++		}
++		Logger.Infof("[%s] public key: %X\n", config.Moniker, pubKeyBytes)
++		address, err := GetAddress(pubKey, config.AddressPrefix)
++		if err != nil {
++			common.Panic(err)
+ 		}
+ 		Logger.Debugf("[%s] address is: %s\n", config.Moniker, address)
+ 		params := tss.NewParameters(tss.EC(), p2pCtx, partyID, config.Parties, config.Threshold)
+@@ -271,9 +274,17 @@ func (client *TssClient) handleMessageRoutine() {
  		if err != nil {
  			common.Panic(fmt.Errorf("[%s] failed to extract message inside message wrapper: %v", client.config.Moniker, err))
  		}
@@ -21,6 +79,151 @@ index 35ca66f..f7d234d 100644
  			messageWrapper.IsBroadcast)
  		if !ok && err != nil {
  			common.Panic(fmt.Errorf("[%s] error updating local party state: %v", client.config.Moniker, err))
+@@ -306,7 +317,7 @@ func (client *TssClient) sendMessageRoutine(sendCh <-chan tss.Message) {
+ 	}
+ }
+ 
+-func (client *TssClient) saveDataRoutine(saveCh <-chan keygen.LocalPartySaveData, done chan<- bool) {
++func (client *TssClient) saveDataRoutine(saveCh <-chan *keygen.LocalPartySaveData, done chan<- bool) {
+ 	for msg := range saveCh {
+ 		// Used for debugging signature verification failed issue, never uncomment in production!
+ 		//plainJson, err := json.Marshal(msg)
+@@ -325,7 +336,7 @@ func (client *TssClient) saveDataRoutine(saveCh <-chan keygen.LocalPartySaveData
+ 			}
+ 		}
+ 
+-		address, err := GetAddress(ecdsa.PublicKey{tss.EC(), msg.ECDSAPub.X(), msg.ECDSAPub.Y()}, client.config.AddressPrefix)
++		address, err := GetAddress(ecdsa.PublicKey{Curve: tss.EC(), X: msg.ECDSAPub.X(), Y: msg.ECDSAPub.Y()}, client.config.AddressPrefix)
+ 		if err != nil {
+ 			Logger.Errorf("[%s] failed to generate address from public key :%v", client.config.Moniker, err)
+ 		} else {
+@@ -342,7 +353,7 @@ func (client *TssClient) saveDataRoutine(saveCh <-chan keygen.LocalPartySaveData
+ 			common.Panic(err)
+ 		}
+ 		defer wPub.Close() // defer within loop is fine here as for one party there would be only one element from saveCh
+-		err = common.Save(&msg, client.transporter.NodeKey(), client.config.KDFConfig, client.config.Password, wPriv, wPub)
++		err = common.Save(msg, client.transporter.NodeKey(), client.config.KDFConfig, client.config.Password, wPriv, wPub)
+ 		if err != nil {
+ 			common.Panic(err)
+ 		}
+@@ -355,7 +366,7 @@ func (client *TssClient) saveDataRoutine(saveCh <-chan keygen.LocalPartySaveData
+ 	}
+ }
+ 
+-func (client *TssClient) saveSignatureRoutine(signCh <-chan lib.SignatureData, done chan<- bool) {
++func (client *TssClient) saveSignatureRoutine(signCh <-chan *lib.SignatureData, done chan<- bool) {
+ 	for signature := range signCh {
+ 		client.signature = signature.Signature
+ 		if done != nil {
+diff --git a/client/keys.go b/client/keys.go
+index cd138e9..d8eecc4 100644
+--- a/client/keys.go
++++ b/client/keys.go
+@@ -6,9 +6,8 @@ import (
+ 	"math/big"
+ 
+ 	"github.com/bgentry/speakeasy"
+-	"github.com/bnb-chain/tss-lib/v2/ecdsa/signing"
+-	"github.com/bnb-chain/tss-lib/v2/tss"
+-	"github.com/btcsuite/btcd/btcec"
++	"github.com/bnb-chain/tss-lib/v3/ecdsa/signing"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 	"github.com/tendermint/tendermint/crypto"
+ 	"github.com/tendermint/tendermint/crypto/secp256k1"
+ 
+@@ -84,10 +83,12 @@ func LoadPubkey(home, vault string) (crypto.PubKey, error) {
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	btcecPubKey := (*btcec.PublicKey)(ecdsaPubKey)
+-
++	compressed, err := compressedPubKey(*ecdsaPubKey)
++	if err != nil {
++		return nil, err
++	}
+ 	var pubkeyBytes secp256k1.PubKeySecp256k1
+-	copy(pubkeyBytes[:], btcecPubKey.SerializeCompressed())
++	copy(pubkeyBytes[:], compressed)
+ 	return pubkeyBytes, nil
+ }
+ 
+@@ -105,9 +106,11 @@ func loadPubkeyAsCompressedHexString(home, vault string) (string, error) {
+ 	if err != nil {
+ 		return "", err
+ 	}
+-	btcecPubKey := (*btcec.PublicKey)(ecdsaPubKey)
+-
+-	return hex.EncodeToString(btcecPubKey.SerializeCompressed()), nil
++	compressed, err := compressedPubKey(*ecdsaPubKey)
++	if err != nil {
++		return "", err
++	}
++	return hex.EncodeToString(compressed), nil
+ }
+ 
+ func ParseCompressedPubkey(pubkey string) (crypto.PubKey, error) {
+diff --git a/client/utils.go b/client/utils.go
+index 4c5711a..5092ec0 100644
+--- a/client/utils.go
++++ b/client/utils.go
+@@ -7,11 +7,10 @@ import (
+ 	"os"
+ 	"path"
+ 
+-	"github.com/bnb-chain/tss-lib/v2/crypto"
+-	"github.com/bnb-chain/tss-lib/v2/crypto/paillier"
+-	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+-	"github.com/bnb-chain/tss-lib/v2/tss"
+-	"github.com/btcsuite/btcd/btcec"
++	"github.com/bnb-chain/tss-lib/v3/crypto"
++	"github.com/bnb-chain/tss-lib/v3/crypto/paillier"
++	"github.com/bnb-chain/tss-lib/v3/ecdsa/keygen"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 	"github.com/btcsuite/btcutil/bech32"
+ 	"github.com/pkg/errors"
+ 	"golang.org/x/crypto/ripemd160"
+@@ -120,9 +119,11 @@ func appendIfNotExist(target []string, new string) []string {
+ }
+ 
+ func GetAddress(key ecdsa.PublicKey, prefix string) (string, error) {
+-	btcecPubKey := btcec.PublicKey(key)
+ 	// be consistent with tendermint/crypto
+-	compressed := btcecPubKey.SerializeCompressed()
++	compressed, err := compressedPubKey(key)
++	if err != nil {
++		return "", err
++	}
+ 	hasherSHA256 := sha256.New()
+ 	hasherSHA256.Write(compressed[:]) // does not error
+ 	sha := hasherSHA256.Sum(nil)
+@@ -137,3 +138,27 @@ func GetAddress(key ecdsa.PublicKey, prefix string) (string, error) {
+ 	}
+ 	return bech32.Encode(prefix, converted)
+ }
++
++// compressedPubKey serializes public keys for curves whose field size matches
++// the coordinate byte length used by SEC 1 compressed point encoding.
++func compressedPubKey(key ecdsa.PublicKey) ([]byte, error) {
++	if key.Curve == nil || key.X == nil || key.Y == nil {
++		return nil, errors.New("invalid public key: curve, x, and y must be set")
++	}
++
++	params := key.Curve.Params()
++	byteLen := (params.BitSize + 7) / 8
++	xBytes := key.X.Bytes()
++	if len(xBytes) > byteLen {
++		return nil, errors.New("invalid public key: x coordinate is too large for curve")
++	}
++
++	compressed := make([]byte, byteLen+1)
++	if key.Y.Bit(0) == 0 {
++		compressed[0] = 0x02
++	} else {
++		compressed[0] = 0x03
++	}
++	copy(compressed[1+byteLen-len(xBytes):], xBytes)
++	return compressed, nil
++}
 diff --git a/cmd/bootstrapping.go b/cmd/bootstrapping.go
 index b913748..78b9c7a 100644
 --- a/cmd/bootstrapping.go
@@ -283,10 +486,47 @@ index 2b9069e..d6ab2d1 100644
  	})
  	if err != nil {
  		return err
+diff --git a/common/keystore.go b/common/keystore.go
+index dc53e0a..7cf936b 100644
+--- a/common/keystore.go
++++ b/common/keystore.go
+@@ -16,10 +16,10 @@ import (
+ 	"os"
+ 	"path"
+ 
+-	"github.com/bnb-chain/tss-lib/v2/crypto"
+-	"github.com/bnb-chain/tss-lib/v2/crypto/paillier"
+-	"github.com/bnb-chain/tss-lib/v2/ecdsa/keygen"
+-	"github.com/bnb-chain/tss-lib/v2/tss"
++	"github.com/bnb-chain/tss-lib/v3/crypto"
++	"github.com/bnb-chain/tss-lib/v3/crypto/paillier"
++	"github.com/bnb-chain/tss-lib/v3/ecdsa/keygen"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 	"golang.org/x/crypto/argon2"
+ 	"golang.org/x/crypto/sha3"
+ )
+@@ -246,7 +246,7 @@ func LoadEcdsaPubkey(home, vault, passphrase string) (*ecdsa.PublicKey, error) {
+ 		return nil, err
+ 	}
+ 
+-	return &ecdsa.PublicKey{tss.EC(), pFields.ECDSAPub.X(), pFields.ECDSAPub.Y()}, nil
++	return &ecdsa.PublicKey{Curve: tss.EC(), X: pFields.ECDSAPub.X(), Y: pFields.ECDSAPub.Y()}, nil
+ }
+ 
+ func LoadConfig(home, vault, passphrase string) (*TssConfig, error) {
 diff --git a/common/messages.go b/common/messages.go
-index 10b69c5..5955ce7 100644
+index 10b69c5..59a847d 100644
 --- a/common/messages.go
 +++ b/common/messages.go
+@@ -3,7 +3,7 @@ package common
+ import (
+ 	"encoding/gob"
+ 
+-	"github.com/bnb-chain/tss-lib/v2/tss"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ )
+ 
+ func init() {
 @@ -39,6 +39,7 @@ type PeerParam struct {
  	ChannelId, Moniker, Msg, Id string
  	N, T, NewN, NewT            int
@@ -295,10 +535,587 @@ index 10b69c5..5955ce7 100644
  }
  
  func NewBootstrapMessage(channelId, channelPassword, addr string, param PeerParam) (*BootstrapMessage, error) {
+diff --git a/common/transporter.go b/common/transporter.go
+index 39fb1c4..aea2abf 100644
+--- a/common/transporter.go
++++ b/common/transporter.go
+@@ -1,7 +1,7 @@
+ package common
+ 
+ import (
+-	"github.com/bnb-chain/tss-lib/v2/tss"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ )
+ 
+ // Transportation layer of TssClient provide Broadcast and Send method over p2p network
+diff --git a/go.mod b/go.mod
+index a6a9199..605483d 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,21 +1,17 @@
+ module github.com/bnb-chain/tss
+ 
+-go 1.12
++go 1.23
++
++toolchain go1.23.12
+ 
+ require (
+ 	github.com/bgentry/speakeasy v0.1.0
+-	github.com/bnb-chain/tss-lib/v2 v2.0.0
+-	github.com/btcsuite/btcd v0.20.0-beta
+-	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
+-	github.com/go-kit/kit v0.9.0 // indirect
+-	github.com/gogo/protobuf v1.3.1 // indirect
+-	github.com/hashicorp/golang-lru v0.5.3 // indirect
+-	github.com/ipfs/go-cid v0.0.3 // indirect
++	github.com/bnb-chain/tss-lib/v3 v3.0.0
++	github.com/btcsuite/btcutil v1.0.2
+ 	github.com/ipfs/go-datastore v0.0.5
+ 	github.com/ipfs/go-ds-leveldb v0.0.1
+-	github.com/ipfs/go-log v0.0.1
++	github.com/ipfs/go-log v1.0.5
+ 	github.com/koron/go-ssdp v0.0.0-20180514024734-4a0ed625a78b
+-	github.com/libp2p/go-eventbus v0.1.0 // indirect
+ 	github.com/libp2p/go-libp2p v0.3.0
+ 	github.com/libp2p/go-libp2p-circuit v0.1.1
+ 	github.com/libp2p/go-libp2p-core v0.2.2
+@@ -23,33 +19,123 @@ require (
+ 	github.com/libp2p/go-libp2p-peerstore v0.1.3
+ 	github.com/libp2p/go-libp2p-swarm v0.2.0
+ 	github.com/libp2p/go-yamux v1.2.3
+-	github.com/magiconair/properties v1.8.1 // indirect
+-	github.com/mattn/go-colorable v0.1.4 // indirect
+ 	github.com/mattn/go-isatty v0.0.10
+ 	github.com/mitchellh/mapstructure v1.1.2
+ 	github.com/multiformats/go-multiaddr v0.0.4
++	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
++	github.com/pkg/errors v0.9.1
++	github.com/spf13/cobra v0.0.5
++	github.com/spf13/viper v1.4.0
++	github.com/tendermint/tendermint v0.32.2
++	golang.org/x/crypto v0.13.0
++	google.golang.org/protobuf v1.31.0
++)
++
++require (
++	filippo.io/bigmod v0.1.0 // indirect
++	github.com/agl/ed25519 v0.0.0-20200225211852-fd4d107ace12 // indirect
++	github.com/btcsuite/btcd v0.23.4 // indirect
++	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
++	github.com/coreos/go-semver v0.3.0 // indirect
++	github.com/davecgh/go-spew v1.1.1 // indirect
++	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 // indirect
++	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
++	github.com/fsnotify/fsnotify v1.4.7 // indirect
++	github.com/go-kit/kit v0.9.0 // indirect
++	github.com/go-logfmt/logfmt v0.4.0 // indirect
++	github.com/gogo/protobuf v1.3.2 // indirect
++	github.com/golang/protobuf v1.5.0 // indirect
++	github.com/golang/snappy v0.0.1 // indirect
++	github.com/google/uuid v1.1.1 // indirect
++	github.com/gorilla/websocket v1.4.0 // indirect
++	github.com/hashicorp/errwrap v1.0.0 // indirect
++	github.com/hashicorp/go-multierror v1.1.1 // indirect
++	github.com/hashicorp/golang-lru v0.5.3 // indirect
++	github.com/hashicorp/hcl v1.0.0 // indirect
++	github.com/huin/goupnp v1.0.0 // indirect
++	github.com/inconshreveable/mousetrap v1.0.0 // indirect
++	github.com/ipfs/go-cid v0.0.3 // indirect
++	github.com/ipfs/go-ipfs-util v0.0.1 // indirect
++	github.com/ipfs/go-log/v2 v2.1.3 // indirect
++	github.com/ipfs/go-todocounter v0.0.1 // indirect
++	github.com/jackpal/gateway v1.0.5 // indirect
++	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
++	github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2 // indirect
++	github.com/jbenet/goprocess v0.1.3 // indirect
++	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
++	github.com/libp2p/go-addr-util v0.0.1 // indirect
++	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
++	github.com/libp2p/go-conn-security-multistream v0.1.0 // indirect
++	github.com/libp2p/go-eventbus v0.1.0 // indirect
++	github.com/libp2p/go-flow-metrics v0.0.1 // indirect
++	github.com/libp2p/go-libp2p-autonat v0.1.0 // indirect
++	github.com/libp2p/go-libp2p-discovery v0.1.0 // indirect
++	github.com/libp2p/go-libp2p-kbucket v0.2.0 // indirect
++	github.com/libp2p/go-libp2p-loggables v0.1.0 // indirect
++	github.com/libp2p/go-libp2p-mplex v0.2.1 // indirect
++	github.com/libp2p/go-libp2p-nat v0.0.4 // indirect
++	github.com/libp2p/go-libp2p-record v0.1.1 // indirect
++	github.com/libp2p/go-libp2p-routing v0.1.0 // indirect
++	github.com/libp2p/go-libp2p-secio v0.2.0 // indirect
++	github.com/libp2p/go-libp2p-transport-upgrader v0.1.1 // indirect
++	github.com/libp2p/go-libp2p-yamux v0.2.1 // indirect
++	github.com/libp2p/go-maddr-filter v0.0.5 // indirect
++	github.com/libp2p/go-mplex v0.1.0 // indirect
++	github.com/libp2p/go-msgio v0.0.4 // indirect
++	github.com/libp2p/go-nat v0.0.3 // indirect
++	github.com/libp2p/go-openssl v0.0.2 // indirect
++	github.com/libp2p/go-reuseport v0.0.1 // indirect
++	github.com/libp2p/go-reuseport-transport v0.0.2 // indirect
++	github.com/libp2p/go-stream-muxer-multistream v0.2.0 // indirect
++	github.com/libp2p/go-tcp-transport v0.1.0 // indirect
++	github.com/libp2p/go-ws-transport v0.1.0 // indirect
++	github.com/magiconair/properties v1.8.1 // indirect
++	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
++	github.com/minio/sha256-simd v0.1.0 // indirect
++	github.com/mr-tron/base58 v1.1.2 // indirect
++	github.com/multiformats/go-base32 v0.0.3 // indirect
+ 	github.com/multiformats/go-multiaddr-dns v0.0.3 // indirect
++	github.com/multiformats/go-multiaddr-fmt v0.0.1 // indirect
++	github.com/multiformats/go-multiaddr-net v0.0.1 // indirect
++	github.com/multiformats/go-multibase v0.0.1 // indirect
+ 	github.com/multiformats/go-multihash v0.0.7 // indirect
+-	github.com/onsi/ginkgo v1.10.2 // indirect
+-	github.com/onsi/gomega v1.7.0 // indirect
+-	github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 // indirect
+-	github.com/otiai10/mint v1.3.0 // indirect
++	github.com/multiformats/go-multistream v0.1.0 // indirect
++	github.com/opentracing/opentracing-go v1.2.0 // indirect
++	github.com/otiai10/primes v0.0.0-20210501021515-f1b2be525a11 // indirect
+ 	github.com/pelletier/go-toml v1.4.0 // indirect
+-	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+-	github.com/pkg/errors v0.8.1
++	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
++	github.com/spaolacci/murmur3 v1.1.0 // indirect
+ 	github.com/spf13/afero v1.2.2 // indirect
+-	github.com/spf13/cobra v0.0.5
++	github.com/spf13/cast v1.3.0 // indirect
+ 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+-	github.com/spf13/viper v1.4.0
+-	github.com/stretchr/testify v1.4.0 // indirect
++	github.com/spf13/pflag v1.0.3 // indirect
++	github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 // indirect
+ 	github.com/tendermint/go-amino v0.15.0 // indirect
+-	github.com/tendermint/tendermint v0.32.2
+-	github.com/whyrusleeping/go-logging v0.0.1 // indirect
++	github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc // indirect
++	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
++	github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f // indirect
++	github.com/whyrusleeping/mafmt v1.2.8 // indirect
++	github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 // indirect
+ 	go.opencensus.io v0.22.0 // indirect
+-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+-	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
+-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+-	google.golang.org/protobuf v1.27.1
++	go.uber.org/atomic v1.7.0 // indirect
++	go.uber.org/multierr v1.6.0 // indirect
++	go.uber.org/zap v1.16.0 // indirect
++	golang.org/x/net v0.10.0 // indirect
++	golang.org/x/sys v0.12.0 // indirect
++	golang.org/x/text v0.13.0 // indirect
++	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+ 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+-	gopkg.in/yaml.v2 v2.2.4 // indirect
++	gopkg.in/yaml.v2 v2.3.0 // indirect
+ )
++
++// tss-lib/v3 imports agl/ed25519 packages and declares this replacement, but
++// replace directives are not inherited by downstream modules.
++replace github.com/agl/ed25519 => github.com/binance-chain/edwards25519 v0.0.0-20200305024217-f36fc4b53d43
++
++// go-libp2p-core v0.2.2 imports the old github.com/btcsuite/btcd/btcec package,
++// which is absent from newer btcd releases.
++replace github.com/btcsuite/btcd => github.com/btcsuite/btcd v0.20.1-beta
++
++// tss-lib/v3 brings chainhash as a separate module, while the old btcd
++// replacement above also contains github.com/btcsuite/btcd/chaincfg/chainhash.
++exclude github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
+diff --git a/go.sum b/go.sum
+index 17cfc5f..31603fa 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,6 @@
+-bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
+ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
++filippo.io/bigmod v0.1.0 h1:UNzDk7y9ADKST+axd9skUpBQeW7fG2KrTZyOE4uGQy8=
++filippo.io/bigmod v0.1.0/go.mod h1:OjOXDNlClLblvXdwgFFOQFJEocLhhtai8vGLy0JCZlI=
+ github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+ github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
+ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+@@ -8,8 +9,6 @@ github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETF
+ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+-github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
+-github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+@@ -17,19 +16,19 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
+ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
+ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+-github.com/bnb-chain/tss-lib/v2 v2.0.0 h1:VE2X5eWmHSH4u0UI7z87oI/99IJbfevtm3OYDZM48Eg=
+-github.com/bnb-chain/tss-lib/v2 v2.0.0/go.mod h1:7Uai3xfLjJPD2gbd0+/1gHsfqa9PKxONdwDtnt6ZYxc=
+-github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d/go.mod h1:d3C0AkH6BRcvO8T0UEPu53cnw4IbV63x1bEjildYhO0=
+-github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
+-github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
+-github.com/btcsuite/btcd v0.0.0-20190629003639-c26ffa870fd8/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
+-github.com/btcsuite/btcd v0.20.0-beta h1:DnZGUjFbRkpytojHWwy6nfUSA7vFrzWXDLpFNzt74ZA=
+-github.com/btcsuite/btcd v0.20.0-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
++github.com/binance-chain/edwards25519 v0.0.0-20200305024217-f36fc4b53d43 h1:Vkf7rtHx8uHx8gDfkQaCdVfc+gfrF9v6sR6xJy7RXNg=
++github.com/binance-chain/edwards25519 v0.0.0-20200305024217-f36fc4b53d43/go.mod h1:TnVqVdGEK8b6erOMkcyYGWzCQMw7HEMCOw3BgFYCFWs=
++github.com/bnb-chain/tss-lib/v3 v3.0.0 h1:Vqc4qExogT4X61+Jvh7rxJM5RF5ksQxsQjWY3VwbTd0=
++github.com/bnb-chain/tss-lib/v3 v3.0.0/go.mod h1:2YiekCEVQ+XNOq2ECsJDvYeGs1vgK+cfOHJ357XIWIk=
++github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
++github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
++github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
++github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
+ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
+ github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+-github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+-github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
+ github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
++github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
++github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
+ github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
+ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
+ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
+@@ -46,12 +45,16 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
+ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
++github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+-github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0 h1:E5KszxGgpjpmW8vN811G6rBAZg0/S/DftdGqN4FW5x4=
+-github.com/decred/dcrd/dcrec/edwards/v2 v2.0.0/go.mod h1:d0H8xGMWbiIQP7gN3v2rByWUcuZPm9YsgmnfoxgbINc=
++github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
++github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3 h1:l/lhv2aJCUignzls81+wvga0TFlyoZx8QxRMQgXpZik=
++github.com/decred/dcrd/dcrec/edwards/v2 v2.0.3/go.mod h1:AKpV6+wZ2MfPRJnTbQ6NPgWrKzbe9RCIlCF/FKzMtM8=
++github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
++github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+ github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
+ github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+@@ -77,8 +80,8 @@ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
+-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
++github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
++github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+@@ -99,6 +102,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
+ github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
+ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
+ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
++github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+ github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+@@ -111,8 +115,8 @@ github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfm
+ github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
++github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
++github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+ github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
+@@ -142,8 +146,11 @@ github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIyk
+ github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
+ github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
+ github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
+-github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=
+ github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
++github.com/ipfs/go-log v1.0.5 h1:2dOuUCB1Z7uoczMWgAyDck5JLb72zHzrMnGnCNNbvY8=
++github.com/ipfs/go-log v1.0.5/go.mod h1:j0b8ZoR+7+R99LD9jZ6+AJsrzkPbSXbZfGakb5JPtIo=
++github.com/ipfs/go-log/v2 v2.1.3 h1:1iS3IU7aXRlbgUpN8yTTpJ53NXYjAe37vcI5+5nYrzk=
++github.com/ipfs/go-log/v2 v2.1.3/go.mod h1:/8d0SH3Su5Ooc31QlL1WysJhvyOTDCjcCZ9Axpmri6g=
+ github.com/ipfs/go-todocounter v0.0.1 h1:kITWA5ZcQZfrUnDNkRn04Xzh0YFaDFXsoO2A81Eb6Lw=
+ github.com/ipfs/go-todocounter v0.0.1/go.mod h1:l5aErvQc8qKE2r7NDMjmq5UNAvuZy0rC8BHOplkWvZ4=
+ github.com/jackpal/gateway v1.0.5 h1:qzXWUJfuMdlLMtt0a3Dgt+xkWQiA5itDEITVJtuSwMc=
+@@ -166,7 +173,7 @@ github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlT
+ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
+ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+-github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
++github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+@@ -279,12 +286,8 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
+ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+ github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+-github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+-github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+-github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+ github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
+ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+@@ -329,32 +332,31 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
+ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
++github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
+ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+-github.com/onsi/ginkgo v1.10.2 h1:uqH7bpe+ERSiDa34FDOF7RikN6RzXgduUF8yarlZp94=
+-github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
++github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
+ github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+-github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
+-github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+ github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+-github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+-github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
++github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
++github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+-github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776 h1:o59bHXu8Ejas8Kq6pjoVJQ9/neN66SM8AKh6wI42BBs=
+-github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZeFXocWuvtcS0XSFLcf2XUSDHkq9t1jU4=
+-github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGBkR3M=
+-github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
++github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
++github.com/otiai10/jsonindent v0.0.0-20171116142732-447bf004320b/go.mod h1:SXIpH2WO0dyF5YBc6Iq8jc8TEJYe1Fk2Rc1EVYUdIgY=
+ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+-github.com/otiai10/primes v0.0.0-20180210170552-f6d2a1ba97c4 h1:blMAhTXF6uL1+e3eVSajjLT43Cc0U8mU1gcigbbolJM=
+-github.com/otiai10/primes v0.0.0-20180210170552-f6d2a1ba97c4/go.mod h1:UmSP7QeU3XmAdGu5+dnrTJqjBc+IscpVZkQzk473cjM=
++github.com/otiai10/mint v1.3.2 h1:VYWnrP5fXmz1MXvjuUvcBrXSjGE6xjON+axB/UrpO3E=
++github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
++github.com/otiai10/primes v0.0.0-20210501021515-f1b2be525a11 h1:7x5D/2dkkr27Tgh4WFuX+iCS6OzuE5YJoqJzeqM+5mc=
++github.com/otiai10/primes v0.0.0-20210501021515-f1b2be525a11/go.mod h1:1DmRMnU78i/OVkMnHzvhXSi4p8IhYUmtLJWhyOavJc0=
+ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+ github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
+ github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+ github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+ github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
+ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
++github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
++github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+@@ -369,8 +371,11 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
+ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+ github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
++github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+ github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
++github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
++github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+ github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
+ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+@@ -402,8 +407,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
+ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
++github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
++github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+ github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
+ github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
+@@ -416,13 +422,12 @@ github.com/tendermint/tm-db v0.1.1/go.mod h1:0cPKWu2Mou3IlxecH+MEUSYc1Ch537alLe6
+ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
++github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+ github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
+ github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
+ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
+ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
+ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
+-github.com/whyrusleeping/go-logging v0.0.1 h1:fwpzlmT0kRC/Fmd0MdmGgJG/CXIZ6gFq46FQZjprUcc=
+-github.com/whyrusleeping/go-logging v0.0.1/go.mod h1:lDPYj54zutzG1XYfHAhcc7oNXEburHQBn+Iqd4yS4vE=
+ github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f h1:M/lL30eFZTKnomXY6huvM6G0+gVquFNf6mxghaWlFUg=
+ github.com/whyrusleeping/go-notifier v0.0.0-20170827234753-097c5d47330f/go.mod h1:cZNvX9cFybI01GriPRMXDtczuvUhgbcYr9iCGaNlRv8=
+ github.com/whyrusleeping/mafmt v1.2.8 h1:TCghSl5kkwEE0j+sU/gudyhVMRlpBin8fMBBHg59EbA=
+@@ -433,14 +438,25 @@ github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.
+ github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
+ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
++github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
++github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+ go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+ go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+ go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
+ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
++go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
++go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
++go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+ go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
++go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
++go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
++go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
++go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
+ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
++go.uber.org/zap v1.16.0 h1:uFRZXykJGK9lLY4HtgSw44DnIcAM+kRBP7x5m+NpAOM=
++go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
+ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+@@ -448,15 +464,26 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
+ golang.org/x/crypto v0.0.0-20190225124518-7f87c0fbb88b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+ golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
++golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
++golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
++golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
++golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
++golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
+ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
++golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
++golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
++golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
++golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
++golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
++golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
++golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -471,14 +498,18 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
+ golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+-golang.org/x/net v0.0.0-20191021144547-ec77196f6094 h1:5O4U9trLjNpuhpynaDsqwCk+Tw6seqJz1EbqbnzHrc8=
+-golang.org/x/net v0.0.0-20191021144547-ec77196f6094/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
++golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
++golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
++golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
++golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
++golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -492,25 +523,37 @@ golang.org/x/sys v0.0.0-20190228124157-a34e9553db1e/go.mod h1:STP8DvDyc/dI5b8T5h
+ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+ golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
++golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
++golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
++golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
++golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
++golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
++golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+-golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20181130052023-1c3d964395ce/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
++golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
++golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
++golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
++golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
++golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
++golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
++golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
++golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
+ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
++golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
++golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
++golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
++golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+@@ -523,13 +566,14 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
+ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+ google.golang.org/grpc v1.22.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+-google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+-google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
++google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
++google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
++gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+@@ -540,7 +584,11 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
+ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
+ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
+-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
++gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
++gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
++gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
++gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
++honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
++honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+diff --git a/p2p/mem_transporter.go b/p2p/mem_transporter.go
+index fa674b7..915bb69 100644
+--- a/p2p/mem_transporter.go
++++ b/p2p/mem_transporter.go
+@@ -3,7 +3,7 @@ package p2p
+ import (
+ 	"sync"
+ 
+-	"github.com/bnb-chain/tss-lib/v2/tss"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 
+ 	"github.com/bnb-chain/tss/common"
+ )
 diff --git a/p2p/p2p_transporter.go b/p2p/p2p_transporter.go
-index bdf475b..677643f 100644
+index bdf475b..a534787 100644
 --- a/p2p/p2p_transporter.go
 +++ b/p2p/p2p_transporter.go
+@@ -19,7 +19,7 @@ import (
+ 	"sync/atomic"
+ 	"time"
+ 
+-	"github.com/bnb-chain/tss-lib/v2/tss"
++	"github.com/bnb-chain/tss-lib/v3/tss"
+ 	relay "github.com/libp2p/go-libp2p-circuit"
+ 	ifconnmgr "github.com/libp2p/go-libp2p-core/connmgr"
+ 	"github.com/libp2p/go-libp2p-core/crypto"
 @@ -171,8 +171,11 @@ func NewP2PTransporter(
  	if err != nil {
  		common.Panic(err)

--- a/tss-tools/setup-mise-go.sh
+++ b/tss-tools/setup-mise-go.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_GO_VERSION="1.20.3"
+DEFAULT_GO_VERSION="1.23.12"
 DEFAULT_MISE_VERSION="v2026.3.8"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tss-tools/tss_workflow_smoke.sh
+++ b/tss-tools/tss_workflow_smoke.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # - sign on the initial 3-party committee
 # - first regroup from old 3 -> new 5 with new threshold 3
 # - sign on the 5-party committee
-# - second regroup from old 4 -> new 3 using parties 2,3,4,5,
+# - second regroup from old 4 -> new 3 with final threshold 1 using parties 2,3,4,5,
 #   where 3,4,5 remain in the new committee and party 2 is old-only
 # - sign on the final 3-party committee
 
@@ -55,6 +55,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
+require_command() {
+	local cmd="$1"
+	command -v "$cmd" >/dev/null 2>&1 || {
+		echo "$cmd is required but not installed"
+		exit 1
+	}
+}
+
+port_available() {
+	local port="$1"
+	if command -v lsof >/dev/null 2>&1; then
+		! lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+		return
+	fi
+	if command -v nc >/dev/null 2>&1; then
+		! nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+		return
+	fi
+	echo "warning: neither lsof nor nc found; skipping port availability check" >&2
+	return 0
+}
+
+check_required_ports() {
+	local port
+	for port in "${BASE_PORTS[@]}" "${ROUND1_TMP_PORTS[@]}" "${ROUND2_TMP_PORTS[@]}"; do
+		if ! port_available "$port"; then
+			echo "required port is already in use: $port"
+			exit 1
+		fi
+	done
+}
+
 party_home() {
 	local idx="$1"
 	printf '%s/party-%s/chain-103' "$BASE" "$idx"
@@ -101,8 +133,7 @@ fail_phase() {
 }
 
 wait_for_pids() {
-	local label="$1"
-	local timeout="$2"
+	local timeout="$1"
 	local deadline=$((SECONDS + timeout))
 
 	while [ "${#PIDS[@]}" -gt 0 ]; do
@@ -111,6 +142,12 @@ wait_for_pids() {
 		for pid in "${PIDS[@]}"; do
 			if kill -0 "$pid" 2>/dev/null; then
 				remaining+=("$pid")
+			else
+				if wait "$pid"; then
+					:
+				else
+					return 1
+				fi
 			fi
 		done
 		PIDS=()
@@ -126,6 +163,23 @@ wait_for_pids() {
 		fi
 		sleep 1
 	done
+}
+
+check_phase_result() {
+	local phase="$1"
+	local timeout="$2"
+	local status
+
+	set +e
+	wait_for_pids "$timeout"
+	status=$?
+	set -e
+	if [ "$status" -eq 124 ]; then
+		fail_phase "$phase" "$phase timed out; logs in $BASE"
+	fi
+	if [ "$status" -ne 0 ]; then
+		fail_phase "$phase" "$phase failed; logs in $BASE"
+	fi
 }
 
 assert_key_material() {
@@ -190,9 +244,7 @@ run_sign_phase() {
 	for idx in "$@"; do
 		start_sign "$phase" "$channel_id" "$idx"
 	done
-	if ! wait_for_pids "$phase" "$timeout"; then
-		fail_phase "$phase" "$phase timed out; logs in $BASE"
-	fi
+	check_phase_result "$phase" "$timeout"
 
 	for idx in "$@"; do
 		sig="$(signature_from_log "$BASE/$phase-$idx.log")"
@@ -284,6 +336,12 @@ echo "logs: $BASE"
 echo "binary: $BIN_ABS"
 echo "cwd: $TSS_CWD"
 echo "channels: keygen=$KEYGEN_CH sign1=$SIGN1_CH regroup1=$REGROUP1_CH sign2=$SIGN2_CH regroup2=$REGROUP2_CH sign3=$SIGN3_CH"
+require_command expect
+if [ ! -x "$BIN_ABS" ]; then
+	echo "tss binary not found or not executable: $BIN_ABS"
+	exit 1
+fi
+check_required_ports
 echo "phase: init 5 parties"
 
 for idx in 1 2 3 4 5; do
@@ -303,9 +361,7 @@ echo "phase: keygen on parties 1,2,3 with threshold 2"
 start_keygen 1 "$(base_addr 2),$(base_addr 3)"
 start_keygen 2 "$(base_addr 1),$(base_addr 3)"
 start_keygen 3 "$(base_addr 1),$(base_addr 2)"
-if ! wait_for_pids "keygen" 60; then
-	fail_phase "keygen" "keygen timed out; logs in $BASE"
-fi
+check_phase_result "keygen" 60
 assert_key_material 1 2 3
 echo "keygen completed"
 
@@ -320,9 +376,7 @@ start_regroup1 2 "--p2p.new_listen /ip4/0.0.0.0/tcp/19232 --is_old --is_new_memb
 start_regroup1 3 "--p2p.new_listen /ip4/0.0.0.0/tcp/19233 --is_old --is_new_member" "$(base_addr 1),$(base_addr 2),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4),$(base_addr 5)"
 start_regroup1 4 "--is_new_member" "$(base_addr 1),$(base_addr 2),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 5)"
 start_regroup1 5 "--is_new_member" "$(base_addr 1),$(base_addr 2),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4)"
-if ! wait_for_pids "regroup1" 60; then
-	fail_phase "regroup1" "first regroup timed out; logs in $BASE"
-fi
+check_phase_result "regroup1" 60
 assert_key_material 1 2 3 4 5
 echo "first regroup completed"
 
@@ -332,13 +386,13 @@ echo "sign after first regroup completed"
 
 PIDS=()
 echo "phase: second regroup old 4 -> new 3 using parties 2,3,4,5"
+# The second regroup uses new_threshold=1 intentionally for a minimal
+# final 2-of-3 smoke-test committee.
 start_regroup2_old_only 2 "$(round1_committee_addr 3),$(round1_committee_addr 4),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
 start_regroup2_old_new 3 "$(round2_tmp_addr 3)" "$(round1_committee_addr 2),$(round1_committee_addr 4),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
 start_regroup2_old_new 4 "$(round2_tmp_addr 4)" "$(round1_committee_addr 2),$(round1_committee_addr 3),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
 start_regroup2_old_new 5 "$(round2_tmp_addr 5)" "$(round1_committee_addr 2),$(round1_committee_addr 3),$(round1_committee_addr 4),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
-if ! wait_for_pids "regroup2" 60; then
-	fail_phase "regroup2" "second regroup timed out; logs in $BASE"
-fi
+check_phase_result "regroup2" 60
 assert_key_material 3 4 5
 echo "second regroup completed"
 

--- a/tss-tools/tss_workflow_smoke.sh
+++ b/tss-tools/tss_workflow_smoke.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local smoke test for:
+# - init 5 parties
+# - keygen with parties 1,2,3 at threshold 2
+# - sign on the initial 3-party committee
+# - first regroup from old 3 -> new 5 with new threshold 3
+# - sign on the 5-party committee
+# - second regroup from old 4 -> new 3 using parties 2,3,4,5,
+#   where 3,4,5 remain in the new committee and party 2 is old-only
+# - sign on the final 3-party committee
+
+gen_channel_password() {
+	if command -v openssl >/dev/null 2>&1; then
+		openssl rand -hex 32
+	else
+		od -An -N32 -tx1 /dev/urandom | tr -d ' \n'
+	fi
+}
+
+SIGNER_ROOT="${SIGNER_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+BIN="${BIN:-$SIGNER_ROOT/tss/.tooling/bin/tss}"
+if [[ "$BIN" = /* ]]; then
+	BIN_ABS="$BIN"
+else
+	BIN_ABS="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+fi
+TSS_CWD="${TSS_CWD:-$(dirname "$BIN_ABS")}"
+BASE="${BASE:-$(mktemp -d /private/tmp/tss-workflow-smoke.XXXXXX)}"
+PASS="${PASS:-1234567890}"
+MESSAGE="${MESSAGE:-1234567890}"
+CHPASS="${CHPASS:-$(gen_channel_password)}"
+KEYGEN_CH="${KEYGEN_CH:-$(printf '515%08X' "$(($(date +%s)+2400))")}"
+SIGN1_CH="${SIGN1_CH:-$(printf '611%08X' "$(($(date +%s)+2400))")}"
+REGROUP1_CH="${REGROUP1_CH:-$(printf '761%08X' "$(($(date +%s)+2400))")}"
+SIGN2_CH="${SIGN2_CH:-$(printf '612%08X' "$(($(date +%s)+2400))")}"
+REGROUP2_CH="${REGROUP2_CH:-$(printf '762%08X' "$(($(date +%s)+2400))")}"
+SIGN3_CH="${SIGN3_CH:-$(printf '613%08X' "$(($(date +%s)+2400))")}"
+
+BASE_PORTS=(19131 19132 19133 19134 19135)
+ROUND1_TMP_PORTS=(19231 19232 19233)
+ROUND2_TMP_PORTS=(19333 19334 19335)
+PIDS=()
+
+cleanup() {
+	local pid
+	local pids=("${PIDS[@]:-}")
+	PIDS=()
+	for pid in "${pids[@]}"; do
+		pkill -P "$pid" 2>/dev/null || true
+		kill "$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+	done
+}
+trap cleanup EXIT
+
+party_home() {
+	local idx="$1"
+	printf '%s/party-%s/chain-103' "$BASE" "$idx"
+}
+
+base_addr() {
+	local idx="$1"
+	printf '/ip4/127.0.0.1/tcp/%s' "${BASE_PORTS[$((idx - 1))]}"
+}
+
+round1_tmp_addr() {
+	local idx="$1"
+	printf '/ip4/127.0.0.1/tcp/%s' "${ROUND1_TMP_PORTS[$((idx - 1))]}"
+}
+
+round2_tmp_addr() {
+	local idx="$1"
+	printf '/ip4/127.0.0.1/tcp/%s' "${ROUND2_TMP_PORTS[$((idx - 3))]}"
+}
+
+round1_committee_addr() {
+	local idx="$1"
+	case "$idx" in
+		1) round1_tmp_addr 1 ;;
+		2) round1_tmp_addr 2 ;;
+		3) round1_tmp_addr 3 ;;
+		4) base_addr 4 ;;
+		5) base_addr 5 ;;
+		*) return 1 ;;
+	esac
+}
+
+run_tss() {
+	(cd "$TSS_CWD" && "$BIN_ABS" "$@")
+}
+
+fail_phase() {
+	local _phase="$1"
+	local message="$2"
+	cleanup
+	echo "$message"
+	echo "logs: $BASE"
+	exit 1
+}
+
+wait_for_pids() {
+	local label="$1"
+	local timeout="$2"
+	local deadline=$((SECONDS + timeout))
+
+	while [ "${#PIDS[@]}" -gt 0 ]; do
+		local remaining=()
+		local pid
+		for pid in "${PIDS[@]}"; do
+			if kill -0 "$pid" 2>/dev/null; then
+				remaining+=("$pid")
+			fi
+		done
+		PIDS=()
+		if [ "${#remaining[@]}" -gt 0 ]; then
+			PIDS=("${remaining[@]}")
+		fi
+
+		if [ "${#PIDS[@]}" -eq 0 ]; then
+			return 0
+		fi
+		if [ "$SECONDS" -gt "$deadline" ]; then
+			return 124
+		fi
+		sleep 1
+	done
+}
+
+assert_key_material() {
+	local idx
+	for idx in "$@"; do
+		test -s "$(party_home "$idx")/default/sk.json"
+		test -s "$(party_home "$idx")/default/pk.json"
+	done
+}
+
+signature_from_log() {
+	local log_file="$1"
+	sed -n 's/.*received signature: \([0-9A-F]*\).*/\1/p' "$log_file" | tail -n1
+}
+
+start_keygen() {
+	local idx="$1"
+	local peers="$2"
+
+	run_tss keygen \
+		--home "$(party_home "$idx")" \
+		--vault_name default \
+		--parties 3 \
+		--threshold 2 \
+		--password "$PASS" \
+		--channel_password "$CHPASS" \
+		--channel_id "$KEYGEN_CH" \
+		--p2p.peer_addrs "$peers" \
+		--log_level debug \
+		> "$BASE/keygen-$idx.log" 2>&1 &
+	PIDS+=("$!")
+}
+
+start_sign() {
+	local phase="$1"
+	local channel_id="$2"
+	local idx="$3"
+
+	run_tss sign \
+		--home "$(party_home "$idx")" \
+		--vault_name default \
+		--password "$PASS" \
+		--channel_password "$CHPASS" \
+		--channel_id "$channel_id" \
+		--message "$MESSAGE" \
+		--log_level debug \
+		> "$BASE/$phase-$idx.log" 2>&1 &
+	PIDS+=("$!")
+}
+
+run_sign_phase() {
+	local phase="$1"
+	local channel_id="$2"
+	local timeout="$3"
+	shift 3
+
+	local idx
+	local sig
+	local ref_sig=""
+
+	PIDS=()
+	for idx in "$@"; do
+		start_sign "$phase" "$channel_id" "$idx"
+	done
+	if ! wait_for_pids "$phase" "$timeout"; then
+		fail_phase "$phase" "$phase timed out; logs in $BASE"
+	fi
+
+	for idx in "$@"; do
+		sig="$(signature_from_log "$BASE/$phase-$idx.log")"
+		if [ -z "$sig" ]; then
+			fail_phase "$phase" "$phase missing signature output for party $idx; logs in $BASE"
+		fi
+		if [ -z "$ref_sig" ]; then
+			ref_sig="$sig"
+		elif [ "$sig" != "$ref_sig" ]; then
+			fail_phase "$phase" "$phase produced mismatched signatures; logs in $BASE"
+		fi
+	done
+}
+
+start_regroup1() {
+	local idx="$1"
+	local extra_flags="$2"
+	local new_peer_addrs="$3"
+
+	# shellcheck disable=SC2086
+	run_tss regroup \
+		--home "$(party_home "$idx")" \
+		--vault_name default \
+		--password "$PASS" \
+		--log_level debug \
+		--channel_id "$REGROUP1_CH" \
+		--channel_password "$CHPASS" \
+		--threshold 2 \
+		--parties 3 \
+		--new_threshold 3 \
+		--new_parties 5 \
+		--p2p.new_peer_addrs "$new_peer_addrs" \
+		$extra_flags \
+		> "$BASE/regroup1-$idx.log" 2>&1 &
+	PIDS+=("$!")
+}
+
+start_regroup2_old_only() {
+	local idx="$1"
+	local new_peer_addrs="$2"
+
+expect <<EOF > "$BASE/regroup2-$idx.log" 2>&1 &
+set timeout -1
+cd "$TSS_CWD"
+spawn "$BIN_ABS" regroup \
+	--home "$(party_home "$idx")" \
+	--vault_name default \
+	--password "$PASS" \
+	--log_level debug \
+	--channel_id "$REGROUP2_CH" \
+	--channel_password "$CHPASS" \
+	--threshold 3 \
+	--parties 5 \
+	--new_threshold 1 \
+	--new_parties 3 \
+	--p2p.new_peer_addrs "$new_peer_addrs"
+expect "Participant as a old committee?*" { send "y\r" }
+expect "Participant as a new committee?*" { send "n\r" }
+expect eof
+EOF
+	PIDS+=("$!")
+}
+
+start_regroup2_old_new() {
+	local idx="$1"
+	local new_listen="$2"
+	local new_peer_addrs="$3"
+
+	run_tss regroup \
+		--home "$(party_home "$idx")" \
+		--vault_name default \
+		--password "$PASS" \
+		--log_level debug \
+		--channel_id "$REGROUP2_CH" \
+		--channel_password "$CHPASS" \
+		--threshold 3 \
+		--parties 5 \
+		--new_threshold 1 \
+		--new_parties 3 \
+		--p2p.new_listen "$new_listen" \
+		--p2p.new_peer_addrs "$new_peer_addrs" \
+		--is_old \
+		--is_new_member \
+		> "$BASE/regroup2-$idx.log" 2>&1 &
+	PIDS+=("$!")
+}
+
+echo "logs: $BASE"
+echo "binary: $BIN_ABS"
+echo "cwd: $TSS_CWD"
+echo "channels: keygen=$KEYGEN_CH sign1=$SIGN1_CH regroup1=$REGROUP1_CH sign2=$SIGN2_CH regroup2=$REGROUP2_CH sign3=$SIGN3_CH"
+echo "phase: init 5 parties"
+
+for idx in 1 2 3 4 5; do
+	run_tss init \
+		--home "$(party_home "$idx")" \
+		--vault_name default \
+		--moniker "party-$idx-chain-103" \
+		--password "$PASS" \
+		--p2p.listen "$(base_addr "$idx")" \
+		--log_level debug \
+		> "$BASE/init-$idx.log" 2>&1
+done
+echo "init completed"
+
+PIDS=()
+echo "phase: keygen on parties 1,2,3 with threshold 2"
+start_keygen 1 "$(base_addr 2),$(base_addr 3)"
+start_keygen 2 "$(base_addr 1),$(base_addr 3)"
+start_keygen 3 "$(base_addr 1),$(base_addr 2)"
+if ! wait_for_pids "keygen" 60; then
+	fail_phase "keygen" "keygen timed out; logs in $BASE"
+fi
+assert_key_material 1 2 3
+echo "keygen completed"
+
+echo "phase: sign on parties 1,2,3"
+run_sign_phase "sign-after-keygen" "$SIGN1_CH" 60 1 2 3
+echo "sign after keygen completed"
+
+PIDS=()
+echo "phase: first regroup old 3 -> new 5"
+start_regroup1 1 "--p2p.new_listen /ip4/0.0.0.0/tcp/19231 --is_old --is_new_member" "$(base_addr 2),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4),$(base_addr 5)"
+start_regroup1 2 "--p2p.new_listen /ip4/0.0.0.0/tcp/19232 --is_old --is_new_member" "$(base_addr 1),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4),$(base_addr 5)"
+start_regroup1 3 "--p2p.new_listen /ip4/0.0.0.0/tcp/19233 --is_old --is_new_member" "$(base_addr 1),$(base_addr 2),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4),$(base_addr 5)"
+start_regroup1 4 "--is_new_member" "$(base_addr 1),$(base_addr 2),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 5)"
+start_regroup1 5 "--is_new_member" "$(base_addr 1),$(base_addr 2),$(base_addr 3),$(round1_tmp_addr 1),$(round1_tmp_addr 2),$(round1_tmp_addr 3),$(base_addr 4)"
+if ! wait_for_pids "regroup1" 60; then
+	fail_phase "regroup1" "first regroup timed out; logs in $BASE"
+fi
+assert_key_material 1 2 3 4 5
+echo "first regroup completed"
+
+echo "phase: sign on parties 2,3,4,5"
+run_sign_phase "sign-after-regroup1" "$SIGN2_CH" 60 2 3 4 5
+echo "sign after first regroup completed"
+
+PIDS=()
+echo "phase: second regroup old 4 -> new 3 using parties 2,3,4,5"
+start_regroup2_old_only 2 "$(round1_committee_addr 3),$(round1_committee_addr 4),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
+start_regroup2_old_new 3 "$(round2_tmp_addr 3)" "$(round1_committee_addr 2),$(round1_committee_addr 4),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
+start_regroup2_old_new 4 "$(round2_tmp_addr 4)" "$(round1_committee_addr 2),$(round1_committee_addr 3),$(round1_committee_addr 5),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
+start_regroup2_old_new 5 "$(round2_tmp_addr 5)" "$(round1_committee_addr 2),$(round1_committee_addr 3),$(round1_committee_addr 4),$(round2_tmp_addr 3),$(round2_tmp_addr 4),$(round2_tmp_addr 5)"
+if ! wait_for_pids "regroup2" 60; then
+	fail_phase "regroup2" "second regroup timed out; logs in $BASE"
+fi
+assert_key_material 3 4 5
+echo "second regroup completed"
+
+echo "phase: sign on parties 3,4"
+run_sign_phase "sign-after-regroup2" "$SIGN3_CH" 60 3 4
+echo "sign after second regroup completed"


### PR DESCRIPTION
- Upgrade the patched native TSS module to tss-lib/v3 and Go 1.23.12.

- Refresh build helpers and setup scripts to use the matching vendored Go toolchain.

- Add a local keygen/sign/regroup smoke workflow covering 3-party keygen, 5-party regroup, and final 3-party regroup.

- Document the tss-lib/v3 patch and dependency rationale.