### PR TITLE
Fix mise bootstrap platform naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If `npm run tss-build` says the Go toolchain is missing, bootstrap the local ven
 ./tss-tools/setup-mise-go.sh
 ```
 
-The vendored Go bootstrap supports macOS and Linux on supported CPU architectures (`darwin-arm64`, `linux-x64`, `linux-arm64`). Windows is not supported by this bootstrap flow.
+The vendored Go bootstrap supports macOS and Linux on supported CPU architectures (`macos-arm64`, `macos-x64`, `linux-x64`, `linux-arm64`). Windows is not supported by this bootstrap flow.
 
 Then build:
 
@@ -179,7 +179,7 @@ These scripts live under [`tss-tools/`](tss-tools) and are the operator-facing h
 | Path | Purpose |
 |---|---|
 | `tss-tools/build-tss.sh` | Builds the Liberdus forked `bnb-chain/tss` checkout to `./tss/.tooling/bin/tss` plus `./tss/.tooling/bin/tss-derive-pubkey`. |
-| `tss-tools/setup-mise-go.sh` | Bootstraps a local Go toolchain under `tss/.tooling/mise` when system `go` is unavailable. Supports `darwin-arm64`, `linux-x64`, and `linux-arm64`; Windows is not supported. |
+| `tss-tools/setup-mise-go.sh` | Bootstraps a local Go toolchain under `tss/.tooling/mise` when system `go` is unavailable. Supports `macos-arm64`, `macos-x64`, `linux-x64`, and `linux-arm64`; Windows is not supported. |
 | `tss-tools/init.ts` | Initializes one native TSS party home and vault for a given party index and chain id. |
 | `tss-tools/keygen.ts` | Runs native TSS keygen for one party using the shared channel settings and `params.json` defaults unless overridden. By default it supplies deterministic local `--p2p.peer_addrs` for same-host committees. |
 | `tss-tools/verify.ts` | Derives and prints the compressed pubkey, Ethereum pubkey, or Ethereum address from an existing native vault. |

--- a/tss-tools/README.md
+++ b/tss-tools/README.md
@@ -23,7 +23,7 @@ This directory contains the `tss-signer` native TSS tooling for the Liberdus for
   - Builds the native binary from the Liberdus forked `bnb-chain/tss` checkout to `../tss/.tooling/bin/tss` plus the `tss-derive-pubkey` helper.
 - `setup-mise-go.sh`
   - Bootstraps a local Go toolchain under `tss/.tooling/mise` when the system `go` binary is absent or the wrong version.
-  - Supports `darwin-arm64`, `linux-x64`, and `linux-arm64`.
+  - Supports `macos-arm64`, `macos-x64`, `linux-x64`, and `linux-arm64`.
   - Windows is not supported by this bootstrap flow.
 - `test-sign-rounds.sh`
   - Multi-scenario signing test harness. Runs configurable rounds across 34 startup-delay scenarios for a configurable committee size (default 7-party, threshold=3, min_sign=4 for thorough coverage). Reports PASS/FAIL per scenario. Logs to `test-result.log` and `test-party{1..N}.log`.

--- a/tss-tools/guide.md
+++ b/tss-tools/guide.md
@@ -39,7 +39,8 @@ git submodule update --init --recursive
 ./tss-tools/setup-mise-go.sh
 
 # Supported bootstrap platforms:
-# - darwin-arm64
+# - macos-arm64
+# - macos-x64
 # - linux-x64
 # - linux-arm64
 # Windows is not supported by this bootstrap flow.

--- a/tss-tools/lib/bnbTss.test.ts
+++ b/tss-tools/lib/bnbTss.test.ts
@@ -5,7 +5,11 @@ import * as path from 'node:path'
 import {getIpBasedMoniker, getMoniker, getPartyHome, readStoredListenAddr, resolveMisePlatform} from './bnbTss';
 
 function testResolveMisePlatformSupportsDarwinArm64(): void {
-  assert.equal(resolveMisePlatform('darwin', 'arm64'), 'darwin-arm64');
+  assert.equal(resolveMisePlatform('darwin', 'arm64'), 'macos-arm64');
+}
+
+function testResolveMisePlatformSupportsDarwinX64(): void {
+  assert.equal(resolveMisePlatform('darwin', 'x64'), 'macos-x64');
 }
 
 function testResolveMisePlatformSupportsLinuxX64(): void {
@@ -22,7 +26,7 @@ function testResolveMisePlatformRejectsUnsupportedPlatforms(): void {
     /Windows is not supported/,
   );
   assert.throws(
-    () => resolveMisePlatform('darwin', 'x64'),
+    () => resolveMisePlatform('freebsd', 'x64'),
     /Unsupported platform/,
   );
 }
@@ -100,6 +104,7 @@ function testReadStoredListenAddrReadsOuterConfigListen(): void {
 
 function main(): void {
   testResolveMisePlatformSupportsDarwinArm64();
+  testResolveMisePlatformSupportsDarwinX64();
   testResolveMisePlatformSupportsLinuxX64();
   testResolveMisePlatformSupportsLinuxArm64();
   testResolveMisePlatformRejectsUnsupportedPlatforms();

--- a/tss-tools/lib/bnbTss.ts
+++ b/tss-tools/lib/bnbTss.ts
@@ -183,12 +183,12 @@ export function resolveMisePlatform(platform = process.platform, arch = process.
   const normalizedPlatform = (() => {
     switch (platform) {
       case 'darwin':
-        return 'darwin';
+        return 'macos';
       case 'linux':
         return 'linux';
       default:
         throw new Error(
-          `Unsupported platform '${platform}/${arch}'. Supported platforms: darwin/arm64, linux/x64, linux/arm64. Windows is not supported by this bootstrap flow.`,
+          `Unsupported platform '${platform}/${arch}'. Supported mise platforms: macos-arm64, macos-x64, linux-x64, linux-arm64. Windows is not supported by this bootstrap flow.`,
         );
     }
   })();
@@ -201,20 +201,21 @@ export function resolveMisePlatform(platform = process.platform, arch = process.
         return 'x64';
       default:
         throw new Error(
-          `Unsupported platform '${platform}/${arch}'. Supported platforms: darwin/arm64, linux/x64, linux/arm64. Windows is not supported by this bootstrap flow.`,
+          `Unsupported platform '${platform}/${arch}'. Supported mise platforms: macos-arm64, macos-x64, linux-x64, linux-arm64. Windows is not supported by this bootstrap flow.`,
         );
     }
   })();
 
   const misePlatform = `${normalizedPlatform}-${normalizedArch}`;
   switch (misePlatform) {
-    case 'darwin-arm64':
+    case 'macos-arm64':
+    case 'macos-x64':
     case 'linux-x64':
     case 'linux-arm64':
       return misePlatform;
     default:
       throw new Error(
-        `Unsupported platform '${platform}/${arch}'. Supported platforms: darwin/arm64, linux/x64, linux/arm64. Windows is not supported by this bootstrap flow.`,
+        `Unsupported platform '${platform}/${arch}'. Supported mise platforms: macos-arm64, macos-x64, linux-x64, linux-arm64. Windows is not supported by this bootstrap flow.`,
       );
   }
 }

--- a/tss-tools/setup-mise-go.sh
+++ b/tss-tools/setup-mise-go.sh
@@ -13,6 +13,12 @@ MISE_DATA_DIR="${MISE_ROOT}/data"
 MISE_CONFIG_DIR="${MISE_ROOT}/config"
 GO_BIN="${MISE_DATA_DIR}/installs/go/${DEFAULT_GO_VERSION}/bin/go"
 
+unsupported_platform_message() {
+  local uname_s="$1"
+  local uname_m="$2"
+  echo "Unsupported platform '${uname_s}/${uname_m}'. Supported mise platforms: macos-arm64, macos-x64, linux-x64, linux-arm64. Windows is not supported by this bootstrap flow." >&2
+}
+
 resolve_mise_platform() {
   local uname_s="${1:-$(uname -s)}"
   local uname_m="${2:-$(uname -m)}"
@@ -21,13 +27,13 @@ resolve_mise_platform() {
 
   case "${uname_s}" in
     Darwin)
-      os="darwin"
+      os="macos"
       ;;
     Linux)
       os="linux"
       ;;
     *)
-      echo "Unsupported platform '${uname_s}/${uname_m}'. Supported platforms: darwin/arm64, linux/x86_64, linux/aarch64. Windows is not supported by this bootstrap flow." >&2
+      unsupported_platform_message "${uname_s}" "${uname_m}"
       return 1
       ;;
   esac
@@ -40,17 +46,17 @@ resolve_mise_platform() {
       arch="x64"
       ;;
     *)
-      echo "Unsupported platform '${uname_s}/${uname_m}'. Supported platforms: darwin/arm64, linux/x86_64, linux/aarch64. Windows is not supported by this bootstrap flow." >&2
+      unsupported_platform_message "${uname_s}" "${uname_m}"
       return 1
       ;;
   esac
 
   case "${os}-${arch}" in
-    darwin-arm64|linux-x64|linux-arm64)
+    macos-arm64|macos-x64|linux-x64|linux-arm64)
       printf '%s\n' "${os}-${arch}"
       ;;
     *)
-      echo "Unsupported platform '${uname_s}/${uname_m}'. Supported platforms: darwin/arm64, linux/x86_64, linux/aarch64. Windows is not supported by this bootstrap flow." >&2
+      unsupported_platform_message "${uname_s}" "${uname_m}"
       return 1
       ;;
   esac

--- a/tss-tools/setup-mise-go.test.sh
+++ b/tss-tools/setup-mise-go.test.sh
@@ -15,9 +15,11 @@ assert_eq() {
 }
 
 test_supported_platforms() {
-  assert_eq "$(resolve_mise_platform Darwin arm64)" "darwin-arm64"
+  assert_eq "$(resolve_mise_platform Darwin arm64)" "macos-arm64"
+  assert_eq "$(resolve_mise_platform Darwin x86_64)" "macos-x64"
   assert_eq "$(resolve_mise_platform Linux x86_64)" "linux-x64"
   assert_eq "$(resolve_mise_platform Linux aarch64)" "linux-arm64"
+  assert_eq "$(resolve_mise_archive_name macos-x64)" "mise-${DEFAULT_MISE_VERSION}-macos-x64.tar.gz"
   assert_eq "$(resolve_mise_archive_name linux-x64)" "mise-${DEFAULT_MISE_VERSION}-linux-x64.tar.gz"
 }
 


### PR DESCRIPTION
- Map macOS platforms to mise release asset names

- Support both macos-arm64 and macos-x64 bootstrap archives

- Keep shell and TypeScript mise platform resolution consistent

- Update docs, errors, and tests for current platform names